### PR TITLE
Fix to enable multiple dynamic controls on a single event

### DIFF
--- a/models/SequenceVerificationDataCentric/models/SequenceVerificationDataCentric/SVDCdomain/AESequenceDC/SVDCclasses/AuditEvent/AuditEvent.masl
+++ b/models/SequenceVerificationDataCentric/models/SequenceVerificationDataCentric/SVDCdomain/AESequenceDC/SVDCclasses/AuditEvent/AuditEvent.masl
@@ -23,6 +23,7 @@ theSourceExtraJobInvariantDefn : instance of ExtraJobInvariantDefn;
 theUserExtraJobInvariantDefn : instance of ExtraJobInvariantDefn;
 theSourceExtraJobInvariant : instance of PersistedInvariant;
 theUserExtraJobInvariant : instance of TransientInvariant;
+theDynamicControlDefns : set of instance of DynamicControlDefinition;
 theDynamicControlDefn : instance of DynamicControlDefinition;
 newDynamicControl : instance of DynamicControl;
 loopCount : integer;
@@ -146,52 +147,56 @@ begin
                      
             when aeDataKindEnum.LOOPCONSTRAINT =>  
               // For this Audit Event Occurrence only the following DynamicControlDefinition is allowed
-              theDynamicControlDefn := theAeOccInSequenceDef -> R30;
-              if (theDynamicControlDefn /= null) and (theDynamicControlDefn.dynamicControlName = aeDataElement.aedName) then
-                //Check that the invariant value is not empty
-                if aeDataElement.aedValue /= "" then
-                  // Convert the provided string value to an integer
-                  loopCount := integer'parse(aeDataElement.aedValue);
-                  newDynamicControl := create DynamicControl (jobID => newJob.jobID, 
+              theDynamicControlDefns := theAeOccInSequenceDef -> R30;
+              for theDynamicControlDefn in theDynamicControlDefns loop 
+                if theDynamicControlDefn.dynamicControlName = aeDataElement.aedName then
+                  //Check that the invariant value is not empty
+                  if aeDataElement.aedValue /= "" then
+                    // Convert the provided string value to an integer
+                    loopCount := integer'parse(aeDataElement.aedValue);
+                    newDynamicControl := create DynamicControl (jobID => newJob.jobID, 
                   	                                          dynamicControlName => aeDataElement.aedName, 
                   	                                          expectedDynamicControlValue => loopCount);
-                  link newDynamicControl R29 theDynamicControlDefn;
-                  link newDynamicControl R35 newJob;
-                  // TODO Remove debug message
-  	              logMessage := "Dynamic Control added for jobId = " & jobId & " is of type = " & aeDataElement.aedKind'image & " and value = " & aeDataElement.aedValue'image;
-	              Logger::log(Logger::Information, "AESequenceDC", logMessage);
+                    link newDynamicControl R29 theDynamicControlDefn;
+                    link newDynamicControl R35 newJob;
+                    // TODO Remove debug message
+  	                logMessage := "Dynamic Control added for jobId = " & jobId & " is of type = " & aeDataElement.aedKind'image & " and value = " & aeDataElement.aedValue'image;
+	                Logger::log(Logger::Information, "AESequenceDC", logMessage);
+                  else
+                    // No Loop Count value provided
+                    newJob.failJob("No valid loop count value provided on this audit event data type for - Job Id = " & newJob.jobID & " and Event Type = " & newEventType.AEType);
+                  end if;
                 else
-                  // No Loop Count value provided
-                  newJob.failJob("No valid loop count value provided on this audit event data type for - Job Id = " & newJob.jobID & " and Event Type = " & newEventType.AEType);
+                  // This Loop Count not expected to be provided on this audit event
+                  newJob.failJob("Loop count not expected on this audit event data type for - Job Id = " & newJob.jobID & " and Event Type = " & newEventType.AEType);                   
                 end if;
-              else
-                // This Loop Count not expected to be provided on this audit event
-                newJob.failJob("Loop count not expected on this audit event data type for - Job Id = " & newJob.jobID & " and Event Type = " & newEventType.AEType);
-              end if;
+             end loop;
               
               //exception - if the integer conversion function above fails does it raise an exception?
                 
             when aeDataKindEnum.BRANCHCONSTRAINT =>  
               // For this Audit Event Occurrence only the following DynamicControlDefinition is allowed
-              theDynamicControlDefn := theAeOccInSequenceDef -> R30;
-              if (theDynamicControlDefn /= null) and (theDynamicControlDefn.dynamicControlName = aeDataElement.aedName) then
-                //Check that the invariant value is not empty
-                if aeDataElement.aedValue /= "" then
-                  // Convert the provided string value to an integer
-                  branchCount := integer'parse(aeDataElement.aedValue);
-                  newDynamicControl := create DynamicControl (jobID => newJob.jobID, 
+              theDynamicControlDefns := theAeOccInSequenceDef -> R30;
+              for theDynamicControlDefn in theDynamicControlDefns loop 
+                if theDynamicControlDefn.dynamicControlName = aeDataElement.aedName then
+                  //Check that the invariant value is not empty
+                  if aeDataElement.aedValue /= "" then
+                    // Convert the provided string value to an integer
+                    branchCount := integer'parse(aeDataElement.aedValue);
+                    newDynamicControl := create DynamicControl (jobID => newJob.jobID, 
                   	                                          dynamicControlName => aeDataElement.aedName, 
                   	                                          expectedDynamicControlValue => branchCount);
-                  link newDynamicControl R29 theDynamicControlDefn;
-                  link newDynamicControl R35 newJob;
+                    link newDynamicControl R29 theDynamicControlDefn;
+                    link newDynamicControl R35 newJob;
+                  else
+                    // No Branch Count value provided
+                    newJob.failJob("No valid branch count value provided on this audit event data type for - Job Id = " & newJob.jobID & " and Event Type = " & newEventType.AEType);
+                  end if;
                 else
-                  // No Branch Count value provided
-                  newJob.failJob("No valid branch count value provided on this audit event data type for - Job Id = " & newJob.jobID & " and Event Type = " & newEventType.AEType);
+                  // This Branch Count not expected to be provided on this audit event
+                  newJob.failJob("Branch count not expected on this audit event data type for - Job Id = " & newJob.jobID & " and Event Type = " & newEventType.AEType);
                 end if;
-              else
-                // This Branch Count not expected to be provided on this audit event
-                newJob.failJob("Branch count not expected on this audit event data type for - Job Id = " & newJob.jobID & " and Event Type = " & newEventType.AEType);
-              end if;
+              end loop;  
 
             when others =>
               // Log warning: Unsupported audit event data type

--- a/models/SequenceVerificationDataCentric/models/SequenceVerificationDataCentric/SVDCdomain/AESequenceDC/SVDCclasses/Job/InstanceStateMachine/InstanceStateMachine.masl
+++ b/models/SequenceVerificationDataCentric/models/SequenceVerificationDataCentric/SVDCdomain/AESequenceDC/SVDCclasses/Job/InstanceStateMachine/InstanceStateMachine.masl
@@ -34,6 +34,7 @@ theUserExtraJobInvariantDefn : instance of ExtraJobInvariantDefn;
 theSourceExtraJobInvariant : instance of PersistedInvariant;
 theUserExtraJobInvariant : instance of TransientInvariant;
 theDynamicControlDefn : instance of DynamicControlDefinition;
+theDynamicControlDefns : set of instance of DynamicControlDefinition;
 newDynamicControl : instance of DynamicControl;
 theUserDynamicControlDefn : instance of DynamicControlDefinition;
 theCurrentDynamicControlDefn : instance of DynamicControlDefinition;
@@ -375,7 +376,10 @@ begin
 	                Logger::log(Logger::Information, "AESequenceDC", logMessage); 
 	              else
                     this.failJob("Empty Invariant Value provided for this Job = " & this.jobID & " and Event Type = " & theEventType.AEType);        
-	              end if;                 
+	              end if; 
+	            else                  
+                  // This Invariant not expected to be provided on this audit event
+                  this.failJob("Extra Job Invariant not expected on this audit event data type for - Job Id = " & this.jobID & " and Event Type = " & theEventType.AEType);
                 end if;
             
             else
@@ -386,47 +390,51 @@ begin
             
             when aeDataKindEnum.LOOPCONSTRAINT =>  
               // For this Audit Event Occurrence only the following DynamicControlDefinition is allowed
-              theDynamicControlDefn := theAeOccInSequenceDef -> R30;
-              if (theDynamicControlDefn /= null) and (theDynamicControlDefn.dynamicControlName = aeDataElement.aedName) then
+              theDynamicControlDefns := theAeOccInSequenceDef -> R30;
+              for theDynamicControlDefn in theDynamicControlDefns loop 
+                if theDynamicControlDefn.dynamicControlName = aeDataElement.aedName then
                 //Check that the invariant value is not empty
-                if aeDataElement.aedValue /= "" then
-                  // Convert the provided string value to an integer
-                  loopCount := integer'parse(aeDataElement.aedValue);
-                  newDynamicControl := create DynamicControl (jobID => this.jobID, 
+                  if aeDataElement.aedValue /= "" then
+                    // Convert the provided string value to an integer
+                    loopCount := integer'parse(aeDataElement.aedValue);
+                    newDynamicControl := create DynamicControl (jobID => this.jobID, 
                   	                                          dynamicControlName => aeDataElement.aedName, 
                   	                                          expectedDynamicControlValue => loopCount);
-                  link newDynamicControl R29 theDynamicControlDefn;
-                  link newDynamicControl R35 this;
+                    link newDynamicControl R29 theDynamicControlDefn;
+                    link newDynamicControl R35 this;
+                  else
+                    // No Loop Count value provided
+                    this.failJob("No valid loop count value provided on this audit event data type for - Job Id = " & this.jobID & " and Event Type = " & theEventType.AEType);
+                  end if;
                 else
-                  // No Loop Count value provided
-                  this.failJob("No valid loop count value provided on this audit event data type for - Job Id = " & this.jobID & " and Event Type = " & theEventType.AEType);
+                  // This Loop Count not expected to be provided on this audit event
+                  this.failJob("Loop count not expected on this audit event data type for - Job Id = " & this.jobID & " and Event Type = " & theEventType.AEType);
                 end if;
-              else
-                // This Loop Count not expected to be provided on this audit event
-                this.failJob("Loop count not expected on this audit event data type for - Job Id = " & this.jobID & " and Event Type = " & theEventType.AEType);
-              end if;
+              end loop;  
              
             when aeDataKindEnum.BRANCHCONSTRAINT =>  
               // For this Audit Event Occurrence only the following DynamicControlDefinition is allowed
-              theDynamicControlDefn := theAeOccInSequenceDef -> R30;
-              if (theDynamicControlDefn /= null) and (theDynamicControlDefn.dynamicControlName = aeDataElement.aedName) then
-                //Check that the invariant value is not empty
-                if aeDataElement.aedValue /= "" then
-                  // Convert the provided string value to an integer
-                  branchCount := integer'parse(aeDataElement.aedValue);
-                  newDynamicControl := create DynamicControl (jobID => this.jobID, 
+              theDynamicControlDefns := theAeOccInSequenceDef -> R30;
+              for theDynamicControlDefn in theDynamicControlDefns loop 
+                if theDynamicControlDefn.dynamicControlName = aeDataElement.aedName then
+                  //Check that the invariant value is not empty
+                  if aeDataElement.aedValue /= "" then
+                    // Convert the provided string value to an integer
+                    branchCount := integer'parse(aeDataElement.aedValue);
+                    newDynamicControl := create DynamicControl (jobID => this.jobID, 
                   	                                          dynamicControlName => aeDataElement.aedName, 
                   	                                          expectedDynamicControlValue => branchCount);
-                  link newDynamicControl R29 theDynamicControlDefn;
-                  link newDynamicControl R35 this;
+                    link newDynamicControl R29 theDynamicControlDefn;
+                    link newDynamicControl R35 this;
+                  else
+                    // No Branch Count value provided
+                    this.failJob("No valid branch count value provided on this audit event data type for - Job Id = " & this.jobID & " and Event Type = " & theEventType.AEType);
+                  end if;
                 else
-                  // No Branch Count value provided
-                  this.failJob("No valid branch count value provided on this audit event data type for - Job Id = " & this.jobID & " and Event Type = " & theEventType.AEType);
+                  // This Branch Count not expected to be provided on this audit event
+                  this.failJob("Branch count not expected on this audit event data type for - Job Id = " & this.jobID & " and Event Type = " & theEventType.AEType);
                 end if;
-              else
-                // This Branch Count not expected to be provided on this audit event
-                this.failJob("Branch count not expected on this audit event data type for - Job Id = " & this.jobID & " and Event Type = " & theEventType.AEType);
-              end if;
+              end loop;  
               
               //exception - if the integer conversion function above fails does it raise an exception?
             

--- a/models/SequenceVerificationDataCentric/models/SequenceVerificationDataCentric/SVDCdomain/AESequenceDC/SVDCclasses/SVDCclasses.xtuml
+++ b/models/SequenceVerificationDataCentric/models/SequenceVerificationDataCentric/SVDCdomain/AESequenceDC/SVDCclasses/SVDCclasses.xtuml
@@ -6561,7 +6561,7 @@ INSERT INTO R_FORM
 	VALUES ("b87c5f51-9aeb-453b-81e0-ac59e55fef8e",
 	"b116ff24-9c1d-4d70-af4d-5d2c6c1c8af7",
 	"21e25fb9-9622-4553-b97d-15a73ae941d5",
-	0,
+	1,
 	1,
 	'is_source_of');
 INSERT INTO R_RGO

--- a/models/SequenceVerificationDataCentric/models/SequenceVerificationDataCentric/SVDCdomain/AESequenceDC/functions/functions.masl
+++ b/models/SequenceVerificationDataCentric/models/SequenceVerificationDataCentric/SVDCdomain/AESequenceDC/functions/functions.masl
@@ -189,10 +189,11 @@ begin
               theConstraintDefn := create ConstraintDefinition (constraintDefnId => previousEventType.constraintDefId, jobName => theJobDefn.jobName, constraintType => AND );
             elsif previousEventType.constraintValue = "XOR" then
               theConstraintDefn := create ConstraintDefinition (constraintDefnId => previousEventType.constraintDefId, jobName => theJobDefn.jobName, constraintType => XOR );
-            elsif previousEventType.constraintValue = "LOOPCOUNT" then
-              theConstraintDefn := create ConstraintDefinition (constraintDefnId => previousEventType.constraintDefId, jobName => theJobDefn.jobName, constraintType => LOOPCOUNT );
-            elsif previousEventType.constraintValue = "BRANCHCOUNT" then
-              theConstraintDefn := create ConstraintDefinition (constraintDefnId => previousEventType.constraintDefId, jobName => theJobDefn.jobName, constraintType => BRANCHCOUNT );
+            // TODO Loop Count and Branch Count are not handled here. Remove these in due course.
+            //elsif previousEventType.constraintValue = "LOOPCOUNT" then
+            //  theConstraintDefn := create ConstraintDefinition (constraintDefnId => previousEventType.constraintDefId, jobName => theJobDefn.jobName, constraintType => LOOPCOUNT );
+            //elsif previousEventType.constraintValue = "BRANCHCOUNT" then
+            //  theConstraintDefn := create ConstraintDefinition (constraintDefnId => previousEventType.constraintDefId, jobName => theJobDefn.jobName, constraintType => BRANCHCOUNT );
             else
               logMessage := "Invalid Constraint Value provided : " & previousEventType.constraintValue & "in Job Name = " & jobName;
 	          Logger::log(Logger::Error, "AESequenceDC", logMessage);            


### PR DESCRIPTION
This change made R30 1..* so that a single audit event definition can be the source of multiple dynamic controls such as loop counts and branch counts. Also made some of the error message reporting a bit more consistent.