### PR TITLE
job:  #MUN-152  stop being too tricky

### DIFF
--- a/models/SequenceVerificationDataCentric/puml/Tutorial_10.puml
+++ b/models/SequenceVerificationDataCentric/puml/Tutorial_10.puml
@@ -7,15 +7,15 @@ Tutorial - Multiple Event Occurrences
 @startuml 
 partition "Job with multiple event occurrences" {
   group "Sequence with split with multiple event occurrences"
-      #green:A;
-      :B;
-      :C;
+      #green:A(0);
+      :B(0);
+      :C(0);
       split
         :B(1);
         #red:C(1);
         detach
       split again
-        #red:D;
+        #red:D(0);
         detach
       end split
   end group

--- a/models/SequenceVerificationDataCentric/puml/Tutorial_13.puml
+++ b/models/SequenceVerificationDataCentric/puml/Tutorial_13.puml
@@ -7,7 +7,7 @@ Tutorial - Intra-Job Invariant
 @startuml 
 partition "Job with Intra-Job Invariant" {
   group "Straight Sequence w/ Invariant"
-      #green:A,IINV,SRC,name=X;
+      #green:A,IINV,name=X;
       note right 
         A carries an intra-job
         invariant named X

--- a/models/SequenceVerificationDataCentric/puml/Tutorial_16.puml
+++ b/models/SequenceVerificationDataCentric/puml/Tutorial_16.puml
@@ -8,7 +8,7 @@ Tutorial - Branch Count Definition
 partition "Job with Branch Count Definition" {
   group "Sequence with Branch"
       #green:A;
-      :B,BCNT,SRC,name=Y;
+      :B,BCNT,name=Y;
       note right 
         B will branch by a
         run-time value times.

--- a/models/SequenceVerificationDataCentric/puml/Tutorial_17.puml
+++ b/models/SequenceVerificationDataCentric/puml/Tutorial_17.puml
@@ -7,21 +7,17 @@
 @startuml
 partition "Job with Loop Count Definition" {
   group "Sequence with Loop"
-    #green:A;
+    #green:A,LCNT,user=B,name=X;
+    note right
+      A is the source
+      of the loop counter
+      applied against B.
+    end note
     repeat
       :B;
       :C;
       :D;
-    repeat while (LCNT=X)
-    floating note
-      Name 'LCNT' in the loop
-      condition.  PLUS will
-      deliver the constraint
-      as src event data on an
-      event ahead of the loop
-      and as user event data on
-      an event inside the loop.
-    end note
+    repeat while ("constrained loop")
     #red:E;
 end group
 }

--- a/models/SequenceVerificationDataCentric/puml/Tutorial_18.puml
+++ b/models/SequenceVerificationDataCentric/puml/Tutorial_18.puml
@@ -1,7 +1,15 @@
 @startuml
 partition "Job with Loop and Break" {
   group "Example of Loop with Break"
-    #green:A;
+    #green:A,LCNT,SRC=A,USER=C,name=X;
+    note right
+      A is explicitly the source
+      of a loop constraint and
+      explicitly identifying an
+      user event _not_ in a
+      conditional section of
+      the contained loop.
+    end note
     repeat
       :B;
       :C;
@@ -11,7 +19,7 @@ partition "Job with Loop and Break" {
       else (normal)
         :D;
       endif
-    repeat while (LCNT=X)
+    repeat while ("constrained loop")
     #red:E;
   end group
 }

--- a/models/SequenceVerificationDataCentric/puml/Tutorial_9.puml
+++ b/models/SequenceVerificationDataCentric/puml/Tutorial_9.puml
@@ -1,18 +1,18 @@
 /'
 
-Tutorial - Simple Sequence Definition
+Tutorial - Simple Sequence Definition with Explicit Occurrences
   
 '/
 
 @startuml 
 partition "Job with Simple Sequence" {
   group "Straight Line Sequence"
-      #green:A;
+      #green:A(0);
       :B(0);
-      :C;
+      :C(0);
       :B(1);
       :C(1);
-      #red:D(1);
+      #red:D(0);
   end group
 }
 @enduml


### PR DESCRIPTION
The source of a loop constraint needs to be known. Therefore, we return to the more "event data'ish"
flavour of specifying the loop constraint.
Also, clarify the occurrence ID examples.