### PR TITLE
Remove inaccessible MASL from AuditEvent,AddEventForNewJob

### DIFF
--- a/models/SequenceVerificationDataCentric/models/SequenceVerificationDataCentric/SVDCdomain/AESequenceDC/SVDCclasses/AuditEvent/AuditEvent.masl
+++ b/models/SequenceVerificationDataCentric/models/SequenceVerificationDataCentric/SVDCdomain/AESequenceDC/SVDCclasses/AuditEvent/AuditEvent.masl
@@ -33,11 +33,13 @@ begin
     newEventType := find_only AuditEventDefinition (AEType = aeType);
     if (newEventType /= null) and ((prevAEIds = empty) or (prevAEIds = emptyString)) then
   	  //We have a valid event type and no previous events
+  	  // So check that it is also the first event of a sequence in that Job
       link newEvent R2 newEventType;
       theAeSequenceDef := newEventType -> R1.AESequenceDefinition;
       theJobDef := theAeSequenceDef -> R7;
       theAeInSequenceDef := theAeSequenceDef with newEventType -> R1.AEInSequenceDefinition;
       theAeOccurrencesInSequenceDef := theAeInSequenceDef -> R12;
+      //TODO should the following be a find and then check there is only one since more than one would be a definition error
       theAeOccInSequenceDef := find_one theAeOccurrencesInSequenceDef (isSequenceStart = true);
       if theAeOccInSequenceDef /= null then
         link newEvent R13 theAeOccInSequenceDef;
@@ -47,22 +49,14 @@ begin
         link newSequence R14 theAeSequenceDef;
    
         link newJob R8 theJobDef;
-        if theAeOccInSequenceDef.isSequenceStart then
-          //The the first event for this new Job is a valid event type for starting the sequence
-          // Log info: new Job and event sequence started
-          logMessage := "New Job started - jobId = " & newJob.jobID & ", Initial audit event: " & eventId & " of type " & newEventType.AEType;
-	      Logger::log(Logger::Information, "AESequenceDC", logMessage);
-      
-        else
-          // Log error: first event for new Job is not a valid event to start a sequence
-          newJob.sequencingFailed := true;
-          newJob.failJob("First event for new Job is not a valid event type to start a sequence - Job Id = " & newJob.jobID & " Event Type = " & newEventType.AEType);
-        end if;
-        
-
-      
-      // Process the audit event data for this new event      
-      newEvent.ProcessAuditEventData (aeData);
+        //The the first event for this new Job is a valid event type for starting the sequence
+        // Log info: new Job and event sequence started
+        logMessage := "New Job started - jobId = " & newJob.jobID & ", Initial audit event: " & eventId & " of type " & newEventType.AEType;
+	    Logger::log(Logger::Information, "AESequenceDC", logMessage);
+          
+     
+        // Process the audit event data for this new event      
+        newEvent.ProcessAuditEventData (aeData);
       
         
       else


### PR DESCRIPTION
This change to isSequenceStart=true had already been made. So I removed the test for the same condition that followed, leaving the logMessage part and deleting the inaccessible else part. I also checked that the same problem was not present in JobInProgress when a start event for an additional sequence within the Job is seen. That's fine - no changes needed.