### PR TITLE
job:  #MUN2-14  AEO _event_data load workaround

### DIFF
--- a/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/SystemSpec/InstanceStateMachine/InstanceStateMachine.masl
+++ b/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/SystemSpec/InstanceStateMachine/InstanceStateMachine.masl
@@ -206,7 +206,7 @@ begin
         
         // now check for any event data definition
         // TODO check the schema here
-        for jobType in find JobType() loop
+        for jobType in find JobType() ordered_by (jobTypeName) loop
             fileName := Filesystem::filename(this.configFilePath & jobType.jobTypeName & "_event_data.json");
             if Filesystem::file_exists(fileName) then
                 eventDataTypesJSONString := Filesystem::read_file(fileName);


### PR DESCRIPTION
When AEO reads/updates the system spec, it runs into a forward reference. The reason is that separate event data files are (now) linked by a shared extra-job token.  If the user of the shared item loads ahead of the source, the spec will not find it.
The workaround is to load these files in alphabetical order, meaning that we need to name Source files alphabetically ahead of User files (convenient for 'Source' and 'User' in the name).