### PR TITLE
Fixed bug identified in event type creation

### DIFF
--- a/models/AEOrdering/config/job_definitions2/Other-Test-Job.json
+++ b/models/AEOrdering/config/job_definitions2/Other-Test-Job.json
@@ -2,8 +2,25 @@
   "JobDefinitionName": "Other-Test-Job",
   "Events": [
     {
-      "EventName": "Other-aaa",
+      "EventName": "aaa",
       "SequenceName": "SEQUENCE1",
+      "OccurrenceId": 1,
+      "Application": "app1",
+      "SequenceStart": true,
+      "EventData": [
+        {
+          "EventDataName": "Data1",
+          "EventDataType": "EXTRAJOBINV"
+        },
+        {
+          "EventDataName": "Data2",
+          "EventDataType": "INTRAJOBINV"
+        }
+      ]
+    },
+    {
+      "EventName": "Other-aaa",
+      "SequenceName": "SEQUENCE2",
       "OccurrenceId": 1,
       "Application": "app1",
       "SequenceStart": true
@@ -15,14 +32,14 @@
           "PreviousOccurrenceId": 1
         }
       ],
-      "SequenceName": "SEQUENCE1",
+      "SequenceName": "SEQUENCE2",
       "EventName": "Other-bbb",
       "OccurrenceId": 1,
       "Application": "app1"
     },
     {
       "EventName": "Other-ddd",
-      "SequenceName": "SEQUENCE1",
+      "SequenceName": "SEQUENCE2",
       "PreviousEvents": [
         {
           "PreviousEventName": "Other-bbb",
@@ -31,6 +48,24 @@
       ],
       "OccurrenceId": 1,
       "Application": "app3"
+    },
+    {
+      "EventName": "bbb",
+      "SequenceName": "SEQUENCE1",
+      "PreviousEvents": [
+        {
+          "PreviousEventName": "aaa",
+          "PreviousOccurrenceId": 1
+        }
+      ],
+      "OccurrenceId": 1,
+      "Application": "app3",
+      "EventData": [
+        {
+          "EventDataName": "Data4",
+          "EventDataType": "EXTRAJOBINV"
+        }
+      ]
     }
   ]
 }

--- a/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/AuditEventType/AuditEventType.masl
+++ b/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/AuditEventType/AuditEventType.masl
@@ -10,8 +10,8 @@ dataValue : integer;
 
 begin
 
-	eventType := find_one AuditEventType(eventType = auditEvent.reportedEventType);
 	job := auditEvent -> R9.Job;
+	eventType := find_one AuditEventType(eventType = auditEvent.reportedEventType and jobTypeName = job.reportedJobName);
 	// failed to identify the event
 	if eventType = null then
 		validEvent := false;
@@ -31,7 +31,7 @@ begin
 		
 		// check if the event has dynamic controls that the value is valid. Only integer values are allowed and they have to be greater than 0
 		theAuditEventData := auditEvent.auditEventData;
-		for dynamicControl in (find AuditEventType(eventType = auditEvent.reportedEventType)) -> R19.DynamicControl loop
+		for dynamicControl in (find AuditEventType(eventType = auditEvent.reportedEventType and jobTypeName = job.reportedJobName)) -> R19.DynamicControl loop
 			if theAuditEventData.dataItems'contains(dynamicControl.dynamicControlName) = true then
 				dataValue := integer'parse(theAuditEventData.dataItems[dynamicControl.dynamicControlName]);
 				if dataValue < 1 then

--- a/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/JobType/JobType.masl
+++ b/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/JobType/JobType.masl
@@ -77,7 +77,7 @@ begin
 					end loop;
 				end if;
 				
-				eventType := find_one AuditEventType(eventType = eventTypeName and occurrenceId = occurrenceId);
+				eventType := find_one AuditEventType(eventType = eventTypeName and occurrenceId = occurrenceId and jobTypeName = this.jobTypeName);
 				if eventType = null then
 					eventType := create unique AuditEventType(eventType => eventTypeName, occurrenceId => occurrenceId, jobTypeName => this.jobTypeName,
 						                               sequenceName => sequenceName, isSequenceStart => sequenceStart, isSequenceEnd => sequenceEnd, 
@@ -180,7 +180,7 @@ begin
 				eventTypeName := JSON::get_string(eventDefJSONObject["EventName"]);
 				
 				// now we have extracted the data create the event
-				eventType := find_one AuditEventType(eventType = eventTypeName and occurrenceId = occurrenceId);
+				eventType := find_one AuditEventType(eventType = eventTypeName and occurrenceId = occurrenceId and jobTypeName = this.jobTypeName);
 				if eventType = null then
 					eventType := create unique AuditEventType(eventType => eventTypeName, occurrenceId => occurrenceId, 
 						                               jobTypeName => this.jobTypeName, sequenceName => sequenceName,
@@ -214,7 +214,7 @@ begin
 	for eventRuleJSONElement in eventRulesJSONArray loop
 		eventRuleJSONObject := JSON::get_object(eventRuleJSONElement);
 		auditEventTypeName := JSON::get_string(eventRuleJSONObject["EventName"]);
-		auditEventType := find_one AuditEventType(eventType = auditEventTypeName);
+		auditEventType := find_one AuditEventType(eventType = auditEventTypeName and jobTypeName = this.jobTypeName);
 		if auditEventType /= null then
 			if eventRuleJSONObject'contains("StaleAuditEventDuration") then
 				auditEventType.staleAuditEventDuration := duration'parse(JSON::get_string(eventRuleJSONObject["StaleAuditEventDuration"]));

--- a/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/ReportedAuditEvent/ReportedAuditEvent.masl
+++ b/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/ReportedAuditEvent/ReportedAuditEvent.masl
@@ -30,7 +30,7 @@ begin
 	
 	// build the audit data details to be reported for invariants
 	theAuditEventData := auditEvent.auditEventData;
-	auditEventTypes := find AuditEventType(eventType = auditEvent.reportedEventType);
+	auditEventTypes := find AuditEventType(eventType = auditEvent.reportedEventType and jobTypeName = job.reportedJobName);
 	for auditEventData in auditEventTypes -> R16.DataItemType loop
 		if theAuditEventData.dataItems'contains(auditEventData.dataItemName) = true then
 			reportableAuditEventData.dataName := auditEventData.dataItemName;

--- a/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/tests/tests.masl
+++ b/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/tests/tests.masl
@@ -76,8 +76,31 @@ begin
 				Assertions::assertTrue(false, "Test Config File: Failed to find the correct number of reported event definitions for AEOrdering-Test, expected 8 found " & (jobDefinition.eventDefinitions'length)'image);  
 			end if;
 		elsif jobDefinition.jobName = "Other-Test-Job" then
-			if jobDefinition.eventDefinitions'length = 3 then
-				null;
+			if jobDefinition.eventDefinitions'length = 5 then
+				for reportEventDefinition in jobDefinition.eventDefinitions loop
+					if reportEventDefinition.sequenceName = "SEQUENCE1" and reportEventDefinition.eventType = "aaa" and reportEventDefinition.occurrenceId = 1 and reportEventDefinition.isSequenced = true then
+						null;
+					elsif reportEventDefinition.sequenceName = "SEQUENCE1" and reportEventDefinition.eventType = "bbb" and reportEventDefinition.occurrenceId = 1 and reportEventDefinition.isSequenced = true then
+					    Assertions::assertTrue((reportEventDefinition.previousEventTypes'length = 1), "Unexepected previous event types eventType = bbb");
+						for previousEventType in reportEventDefinition.previousEventTypes loop
+							Assertions::assertTrue((previousEventType.previousEventTypeName = "aaa" and previousEventType.occurrenceId = 1), "");
+						end loop;
+					elsif reportEventDefinition.sequenceName = "SEQUENCE2" and reportEventDefinition.eventType = "Other-aaa" and reportEventDefinition.occurrenceId = 1 and reportEventDefinition.isSequenced = true then
+						null;
+					elsif reportEventDefinition.sequenceName = "SEQUENCE2" and reportEventDefinition.eventType = "Other-bbb" and reportEventDefinition.occurrenceId = 1 and reportEventDefinition.isSequenced = true then
+					    Assertions::assertTrue((reportEventDefinition.previousEventTypes'length = 1), "Unexepected previous event types eventType = Other-aaa");
+						for previousEventType in reportEventDefinition.previousEventTypes loop
+							Assertions::assertTrue((previousEventType.previousEventTypeName = "Other-aaa" and previousEventType.occurrenceId = 1), "");
+						end loop;
+					elsif reportEventDefinition.sequenceName = "SEQUENCE2" and reportEventDefinition.eventType = "Other-ddd" and reportEventDefinition.occurrenceId = 1 and reportEventDefinition.isSequenced = true then
+					    Assertions::assertTrue((reportEventDefinition.previousEventTypes'length = 1), "Unexepected previous event types eventType = Other-bbb");
+						for previousEventType in reportEventDefinition.previousEventTypes loop
+							Assertions::assertTrue((previousEventType.previousEventTypeName = "Other-bbb" and previousEventType.occurrenceId = 1), "");
+						end loop;
+					else
+						Assertions::assertTrue(false, "Unknown reported event definitions for AEOrdering-Test eventType = " & reportEventDefinition.eventType);  
+					end if;
+				end loop;
 			else
 				Assertions::assertTrue(false, "Test Config File: Failed to find the correct number of reported event definitions for Other-Test-Job, expected 3 found " & (jobDefinition.eventDefinitions'length)'image);  
 			end if;


### PR DESCRIPTION
When creating the audit event type AEO needs to check if the event currently exists in the job definition but was checking for the event type exisiting across all job definitions.

In doing the change for providing the jobName to SVDC the search for the existing event type was not constrained to only events in that specific job. When we have two job definitions that contain an event type with the same name when AEO was processing the second job definition it was finding an event type from the first job definition which resulted in the event type not being created.

AEO has been updated to check for event types in the job definition that is being processed.