### PR TITLE
Use AsyncLogger sparingly.

### DIFF
--- a/deploy/config/benchmarking-config.json
+++ b/deploy/config/benchmarking-config.json
@@ -2,7 +2,7 @@
   "SpecUpdateRate": "PT2M",
   "IncomingDirectory": "./incoming",
   "ProcessedDirectory": "./processed",
-  "ReceptionDeletionTime": "PT10M",
+  "ReceptionDeletionTime": "PT0S",
   "ConcurrentReceptionLimit": "1",
   "SchemaValidate": "true",
   "SchemaValidateFrequency": "1",

--- a/deploy/config/pv-config.json
+++ b/deploy/config/pv-config.json
@@ -1,5 +1,5 @@
 {
-  "SpecUpdateRate": "PT100M",
+  "SpecUpdateRate": "PT2M",
   "IncomingDirectory": "./incoming",
   "ProcessedDirectory": "./processed",
   "ReceptionDeletionTime": "PT10M",

--- a/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/AuditEvent/AuditEvent.masl
+++ b/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/AuditEvent/AuditEvent.masl
@@ -61,7 +61,7 @@ begin
 					failedAuditEvent := create FailedAuditEvent(auditEventId => auditEventId, failureTime => timestamp'now, failureReason => failureReason);
 					link failedAuditEvent R4 auditEvent;
 					logMessage := "AEOrdering::AuditEvent.createAuditEvent : " & failureReason;
-					AsyncLogger::log(Logger::Error, "AEOrdering", logMessage);
+					Logger::log(Logger::Error, "AEOrdering", logMessage);
 					eventContent := "JobId = " & job.jobId & " : EventId = " & auditEventId & " : EventType = " & auditEventType & " : FailureReason = " & failureReason;
 					Reporting~>reportEvent(Logger::Error, "aeordering_events_failed", eventContent);
 				end;
@@ -72,13 +72,13 @@ begin
 		previousJob := auditEvent -> R9.Job;
 		if previousJob = job then
 			logMessage := "AEOrdering::AuditEvent.createAuditEvent : Audit Event has previously been reported for the same job, jobId = " & job.jobId & ", auditEventId = " & auditEventId;
-			AsyncLogger::log(Logger::Error, "AEOrdering", logMessage);
+			Logger::log(Logger::Error, "AEOrdering", logMessage);
 			failureReason := "Audit Event has previously been reported for the same job";
 			eventContent := "JobId = " & job.jobId & " : EventId = " & auditEventId & " : EventType = " & auditEventType & " : FailureReason = " & failureReason;
 			Reporting~>reportEvent(Logger::Error, "aeordering_events_failed", eventContent);
 		else
 			logMessage := "AEOrdering::AuditEvent.createAuditEvent : Audit Event has previously been reported for a different job, jobId = " & job.jobId & ", auditEventId = " & auditEventId & ", previous jobId = " & previousJob.jobId;
-			AsyncLogger::log(Logger::Error, "AEOrdering", logMessage);
+			Logger::log(Logger::Error, "AEOrdering", logMessage);
 			failureReason := "Audit Event has previously been reported for a different job. PreviousJobId = " & previousJob.jobId;
 			eventContent := "JobId = " & job.jobId & " : EventId = " & auditEventId & " : EventType = " & auditEventType & " : FailureReason = " & failureReason;
 			Reporting~>reportEvent(Logger::Error, "aeordering_events_failed", eventContent);
@@ -145,7 +145,7 @@ begin
 		end if;
 		
 	else
-		AsyncLogger::log(Logger::Error, "AEOrdering", "setEventState - " & failureReason);
+		Logger::log(Logger::Error, "AEOrdering", "setEventState - " & failureReason);
 		this.eventState := EventStateEnum.FAILED;
 	end if;
 

--- a/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/AuditEventType/AuditEventType.masl
+++ b/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/AuditEventType/AuditEventType.masl
@@ -16,7 +16,7 @@ begin
 	if eventType = null then
 		validEvent := false;
 		failureReason := "JobId = " & job.jobId & " : EventType = " & auditEvent.reportedEventType & " : FailureReason = Event type is not allowed for job name, Job Name = " & auditEvent.reportedJobName;
-		AsyncLogger::log(Logger::Error, "AEOrdering", "validEvent - " & failureReason);
+		Logger::log(Logger::Error, "AEOrdering", "validEvent - " & failureReason);
 	else
 		// check if the reported job name matches the reported job name held for the job
 		// this may be different as the job is created when the first event on the job id is received
@@ -26,7 +26,7 @@ begin
 					                 " : EventType = " & auditEvent.reportedEventType & " : FailureReason = Job names are different, Event Job Name = " & 
 					                 auditEvent.reportedJobName & ", Job Name = " & job.reportedJobName;
 			validEvent := false;		
-			AsyncLogger::log(Logger::Error, "AEOrdering", "validEvent - " & failureReason);
+			Logger::log(Logger::Error, "AEOrdering", "validEvent - " & failureReason);
 		end if;
 		
 		// check if the event has dynamic controls that the value is valid. Only integer values are allowed and they have to be greater than 0
@@ -38,7 +38,7 @@ begin
 					failureReason := "JobId = " & job.jobId & " :  JobType = " & (eventType -> R12.JobType).jobTypeName &
 					                 " : EventType = " & auditEvent.reportedEventType & " : FailureReason = Event type has invalid dynamic control";
 					validEvent := false;
-					AsyncLogger::log(Logger::Error, "AEOrdering", "validEvent - " & failureReason);
+					Logger::log(Logger::Error, "AEOrdering", "validEvent - " & failureReason);
 				end if;
 			end if;
 		end loop;
@@ -51,7 +51,7 @@ exception
 	when others =>
 		failureReason := "JobId = " & job.jobId & " :  JobType = " & (eventType -> R12.JobType).jobTypeName & 
 		                 " : EventType = " & auditEvent.reportedEventType & " : FailureReason = Event type has invalid dynamic control";
-		AsyncLogger::log(Logger::Error, "AEOrdering", "validEvent - " & failureReason);
+		Logger::log(Logger::Error, "AEOrdering", "validEvent - " & failureReason);
 		return false;
 end service;
 //! ACTIVITY END. DO NOT EDIT THIS LINE.

--- a/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/Job/Job.masl
+++ b/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/Job/Job.masl
@@ -33,7 +33,7 @@ begin
 	
 	// now log the failure
 	logMessage := "AEOrdering::Job.failJob : " & failureReason;
-	AsyncLogger::log(Logger::Error, "AEOrdering", logMessage);
+	Logger::log(Logger::Error, "AEOrdering", logMessage);
 	Reporting~>reportEvent(Logger::Information, "aeordering_job_failed", failureReason);
 	
 end service;

--- a/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/JobStore/JobStore.masl
+++ b/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/JobStore/JobStore.masl
@@ -18,13 +18,13 @@ begin
         	if storedJobIdentifier = null then
     			storedJobIdentifier := create StoredJobIdentifier(jobId => tokens[tokens'first + 1], jobTime => timestamp'parse(tokens[tokens'first]));
     		else
-			    AsyncLogger::log(Logger::Information, "AEOrdering", "Duplicate job id recovered from job store JobId = " & tokens[tokens'first + 1]);
+			    Logger::log(Logger::Information, "AEOrdering", "Duplicate job id recovered from job store JobId = " & tokens[tokens'first + 1]);
     		end if;
         end loop;
 	end if;
 exception
 	when others =>
-	    AsyncLogger::log(Logger::Information, "AEOrdering", "Failed to load Job Store filename = " & fileName);
+	    Logger::log(Logger::Information, "AEOrdering", "Failed to load Job Store filename = " & fileName);
 end service;
 //! ACTIVITY END. DO NOT EDIT THIS LINE.
 
@@ -43,7 +43,7 @@ begin
 		jobStoreDevice << storedJobIdentifier.jobTime'image << " " << storedJobIdentifier.jobId << "\n";
 		Filesystem::close(jobStoreDevice);
 	else
-	    AsyncLogger::log(Logger::Information, "AEOrdering", "Duplicate job id reported to job store JobId = " & jobId);
+	    Logger::log(Logger::Information, "AEOrdering", "Duplicate job id reported to job store JobId = " & jobId);
 	end if;
 end service;
 //! ACTIVITY END. DO NOT EDIT THIS LINE.

--- a/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/JobType/JobType.masl
+++ b/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/JobType/JobType.masl
@@ -147,7 +147,7 @@ begin
 				                        link sourceDataItemType R18.constrains dataItemType;
 				                    else
                                         logMessage := "AEOrdering::JobType.loadEventTypes : Failed to process INTRAJOBINV event data item type for unknown Source Event Type " & JSON::get_string(eventDataJSONObject["SourceEventType"]) & ", Occurrence Id " & JSON::get_integer(eventDataJSONObject["SourceEventOccurrenceId"])'image;
-                                        AsyncLogger::log(Logger::Error, "AEOrdering", logMessage);
+                                        Logger::log(Logger::Error, "AEOrdering", logMessage);
                                         raise program_error;
 				                    end if;
 				                else
@@ -201,7 +201,7 @@ begin
 		end if;
 	else
 		logMessage := "AEOrdering::JobType.loadEventTypes : Failed to process event type for unknown Job Type " & jobTypeName;
-		AsyncLogger::log(Logger::Error, "AEOrdering", logMessage);
+		Logger::log(Logger::Error, "AEOrdering", logMessage);
 		raise program_error;
 	end if;
 	

--- a/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/ReportedAuditEvent/ReportedAuditEvent.masl
+++ b/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/ReportedAuditEvent/ReportedAuditEvent.masl
@@ -50,7 +50,7 @@ begin
 		end if;
 	end loop;
 	logMessage := "AEOrdering::ReportedAuditEvent.reportEvent : REPORTING EVENT JobId = " & job.jobId & " : EventId = " & auditEvent.auditEventId & " EventType = " & auditEvent.eventType  & " : PreviousEventId = " & auditEvent.reportedPrevEventIds'image;
-	AsyncLogger::log(Logger::Debug, "AEOrdering", logMessage);
+	Logger::log(Logger::Debug, "AEOrdering", logMessage);
 	Req_IF_Verification~>audit_event(job.jobId, auditEvent.reportedJobName, auditEvent.reportedEventType, auditEvent.auditEventId, auditEvent.reportedAuditEventTime, auditEvent.reportedPrevEventIds, allReportableAuditEventData);
 	// check for any following events that need reporting
 	for followedByEvent in (auditEvent -> R11.isFollowedBy.AuditEvent) loop
@@ -66,18 +66,18 @@ begin
 				delete blockedAuditEvent;
 				followedByEvent.eventState := EventStateEnum.REPORTED;
 				logMessage := "AEOrdering::ReportedAuditEvent.reportEvent : REPORTING BLOCKED EVENT JobId = " & job.jobId & " : EventId = " & followedByEvent.auditEventId & " EventType = " & followedByEvent.eventType  & " : PreviousEventId = " & this.auditEventId;
-				AsyncLogger::log(Logger::Debug, "AEOrdering", logMessage);
+				Logger::log(Logger::Debug, "AEOrdering", logMessage);
 				reportedAuditEvent.reportEvent();
 			else
 				logMessage := "AEOrdering::ReportedAuditEvent.reportEvent : followed by event was not blocked, jobId " & job.jobId & ", eventId " & this.auditEventId & " expected blocked EventId = " & followedByEvent.auditEventId;
-				AsyncLogger::log(Logger::Error, "AEOrdering", logMessage);
+				Logger::log(Logger::Error, "AEOrdering", logMessage);
 				eventContent := "JobId = " & job.jobId & " : EventId = " & auditEvent.auditEventId & " EventType = " & auditEvent.eventType  & " : FailureReason = followed by event was not blocked";
 				Reporting~>reportEvent(Logger::Error, "verifier_failure", eventContent);
 				raise program_error;
 			end if;
 		else
 			logMessage := "AEOrdering::ReportedAuditEvent.reportEvent : EVENT BLOCKED NOT ALL PREVIOUS EVENTS RECEIVED JobId = " & job.jobId & " : EventId = " & followedByEvent.auditEventId  & " EventType = " & followedByEvent.eventType  & " Not all previous events reported do not report this event";
-			AsyncLogger::log(Logger::Debug, "AEOrdering", logMessage);
+			Logger::log(Logger::Debug, "AEOrdering", logMessage);
 		end if;
 	end loop;
 	
@@ -95,7 +95,7 @@ begin
 	// check that all the previous events for this followed by event have been received
 	reportedPreceedingEvents := followingEvent -> R13.PreviousAuditEvent;
 	logMessage := "AEOrdering::ReportedAuditEvent.verifyPreviousEventsAvailable : EventId = " & followingEvent.auditEventId  & " EventType = " & followingEvent.eventType;
-	AsyncLogger::log(Logger::Debug, "AEOrdering", logMessage);
+	Logger::log(Logger::Debug, "AEOrdering", logMessage);
 	for reportedPreceedingEvent in reportedPreceedingEvents loop
 		previousEvent := find_one AuditEvent(auditEventId = reportedPreceedingEvent.previousAuditEventId and eventState = EventStateEnum.REPORTED);
 		if previousEvent = null then
@@ -103,7 +103,7 @@ begin
 			exit;
 		else
 			logMessage := "AEOrdering::ReportedAuditEvent.verifyPreviousEventsAvailable : reportedPreceedingEvent.previousAuditEventId " & reportedPreceedingEvent.previousAuditEventId & " previousEventId = " & previousEvent.auditEventId  & " EventType = " & previousEvent.eventType & " EventState = " & previousEvent.eventState'image;
-			AsyncLogger::log(Logger::Debug, "AEOrdering", logMessage);
+			Logger::log(Logger::Debug, "AEOrdering", logMessage);
 		end if;
 	end loop;
 	

--- a/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/SourceDataItemForwardReference/SourceDataItemForwardReference.masl
+++ b/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/SourceDataItemForwardReference/SourceDataItemForwardReference.masl
@@ -14,7 +14,7 @@ begin
         delete this;
     else
         logMessage := "AEOrdering::JobType.SourceDataItemForwardReference : Failed to process EXTRAJOBINV event data item type for unknown Source Job Type = " & this.sourceJobTypeName & ", Event Data Name = " & this.sourceDataItemName;
-        AsyncLogger::log(Logger::Error, "AEOrdering", logMessage);
+        Logger::log(Logger::Error, "AEOrdering", logMessage);
         raise program_error;
     end if;
 end service;

--- a/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/SystemSpec/InstanceStateMachine/InstanceStateMachine.masl
+++ b/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/SystemSpec/InstanceStateMachine/InstanceStateMachine.masl
@@ -29,7 +29,7 @@ exception
 	when others => 	
 	
 		logMessage := "AEOrdering::SystemSpec.ConfigChecked : failed to load configuration file";
-		AsyncLogger::log(Logger::Error, "AEOrdering", logMessage);
+		Logger::log(Logger::Error, "AEOrdering", logMessage);
 		raise program_error;
 		
 end state;

--- a/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/SystemSpec/SystemSpec.masl
+++ b/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/SystemSpec/SystemSpec.masl
@@ -11,7 +11,7 @@ begin
         mostRecentModificationTime := fileStatus.modification_time;
     else
         logMessage := "AEOrdering::lastModificationTime : failed to locate config file. Specified file = " & this.configFilePath & this.configFile;
-        AsyncLogger::log(Logger::Error, "AEOrdering", logMessage);
+        Logger::log(Logger::Error, "AEOrdering", logMessage);
         raise program_error;
     end if;
     if Filesystem::file_exists(Filesystem::filename(this.jobDefinitionDirectory)) then
@@ -48,7 +48,7 @@ begin
     	end if;
     else
         logMessage := "AEOrdering::locateUpdatedConfig : failed to locate config file. Specified file = " & this.configFilePath & this.configFile;
-        AsyncLogger::log(Logger::Error, "AEOrdering", logMessage);
+        Logger::log(Logger::Error, "AEOrdering", logMessage);
     end if;
     if configUpdates = true then
     	return true; 
@@ -157,14 +157,14 @@ begin
 				                                                 timeoutPeriodForRetreivingStoredInvariants, timeoutPeriodForHangingJob);
         else
             logMessage := "AEOrdering::SystemSpec.ConfigUpdated : Config file invalid:\n" & JSON::dump(configValidationResult, true);
-            AsyncLogger::log(Logger::Debug, "AEOrdering", logMessage);
+            Logger::log(Logger::Debug, "AEOrdering", logMessage);
             raise JSON::JSONException("Config file invalid");
         end if;
         // set the config file mod time
         this.configFileModificationTime := this.lastModificationTime();        
     else
         logMessage := "AEOrdering::ConfigUpdated : failed to locate config file. Specified file = " & this.configFilePath & this.configFile;
-        AsyncLogger::log(Logger::Error, "AEOrdering", logMessage);
+        Logger::log(Logger::Error, "AEOrdering", logMessage);
     end if;
     
     // if the job store does not exist then create it
@@ -211,7 +211,7 @@ begin
         end loop;
     else
         logMessage := "AEOrdering::locateUpdatedConfig : failed to locate job definition directory. Specified directory = " & this.jobDefinitionDirectory;
-        AsyncLogger::log(Logger::Error, "AEOrdering", logMessage);
+        Logger::log(Logger::Error, "AEOrdering", logMessage);
     end if;
 end service;
 //! ACTIVITY END. DO NOT EDIT THIS LINE.
@@ -283,7 +283,7 @@ begin
                     updatedJobTypes := updatedJobTypes & jobType;
                 else
                     logMessage := "AEOrdering::SystemSpec.ConfigUpdated : Job definition file invalid: " & jobDefinitionFile.jobDefinitionFileName & "\n" & JSON::dump(jobTypeValidationResult, true);
-                    AsyncLogger::log(Logger::Debug, logMessage);
+                    Logger::log(Logger::Debug, logMessage);
                     raise JSON::JSONException("Job definition file invalid");
                 end if;
             end if;

--- a/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOrdering.masl
+++ b/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOrdering.masl
@@ -130,7 +130,7 @@ public service AEOrdering::Reporting~>reportEvent ( eventPriority : in Logger::P
                                                    eventLabel : in string,
                                                    eventContent : in string ) is
 begin
-	AsyncLogger::log(eventPriority, "Verifier", eventLabel & " : " & eventContent);
+	Logger::log(eventPriority, "Verifier", eventLabel & " : " & eventContent);
 end service;
 //! ACTIVITY END. DO NOT EDIT THIS LINE.
 

--- a/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/functions/functions.masl
+++ b/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/functions/functions.masl
@@ -23,7 +23,7 @@ instrumentationEventType : string;
 begin
 
 	logMessage := "AEOrdering::AcceptEvent : jobId = " & jobId & ", auditEventType = " & auditEventType & ", auditEventId = " & auditEventId;
-	AsyncLogger::log(Logger::Debug, "AEOrdering", logMessage);
+	Logger::log(Logger::Debug, "AEOrdering", logMessage);
 	systemSpec := find_one SystemSpec();
 	rawJobId := UUID::extract_raw(UUID::formatted_uuid(jobId));
 	lane := integer(rawJobId[rawJobId'last]);

--- a/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/scenarios/scenarios.masl
+++ b/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/scenarios/scenarios.masl
@@ -27,7 +27,7 @@ begin
     	generate SystemSpec.checkConfigUpdate() to systemSpec;
 	else
 		logMessage := "AEOrdering::init : failed to locate config file. Specified file = " & configFilePath & configFile;
-		AsyncLogger::log(Logger::Error, "AEOrdering", logMessage);
+		Logger::log(Logger::Error, "AEOrdering", logMessage);
 		raise program_error;
 	end if;
 
@@ -35,7 +35,7 @@ exception
 	when others =>
 	
 		logMessage := "AEOrdering::init : failed during start up";
-		AsyncLogger::log(Logger::Error, "AEOrdering", logMessage);
+		Logger::log(Logger::Error, "AEOrdering", logMessage);
 		raise program_error;
 	
 end service;

--- a/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/tests/tests.masl
+++ b/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/tests/tests.masl
@@ -7,9 +7,9 @@ auditEvents : sequence of instance of AuditEvent;
 begin
 	
 	logMessage := "AEOrdering::checkJobComplete";
-	AsyncLogger::log(Logger::Information, "AEOrdering", logMessage);
+	Logger::log(Logger::Information, "AEOrdering", logMessage);
 	logMessage := "AEOrdering::checkJobComplete - Test job complete";
-	AsyncLogger::log(Logger::Information, "AEOrdering", logMessage);
+	Logger::log(Logger::Information, "AEOrdering", logMessage);
 	
 	// verify that there are no jobs
 	jobs := find Job();
@@ -260,7 +260,7 @@ reportAuditFailure :  instance of _TEST_Req_IF_Audited_reportAuditFailure;
 begin
         
     logMessage := "AEOrdering::checkInvalidJobDefinition";
-    AsyncLogger::log(Logger::Information, "AEOrdering", logMessage);
+    Logger::log(Logger::Information, "AEOrdering", logMessage);
     
 	reportAuditFailure := find_one _TEST_Req_IF_Audited_reportAuditFailure(jobId = jobId);
 	Assertions::assertTrue((reportAuditFailure /= null), "Failed to find report audit failure jobId = " & jobId & ", eventId = " & eventId);
@@ -286,7 +286,7 @@ failedAuditEvent : instance of FailedAuditEvent;
 begin
         
 	logMessage := "AEOrdering::checkJobFailures";
-    AsyncLogger::log(Logger::Information, "AEOrdering", logMessage);
+    Logger::log(Logger::Information, "AEOrdering", logMessage);
     
     failedJob := find_one FailedJob(jobId = jobId);
 	Assertions::assertTrue((failedJob /= null), "Failed to find Failed Job = " & jobId);
@@ -310,7 +310,7 @@ jobId1 : string := "95a3b3a7-fada-41d5-b7e2-902079e81001";
 begin
         
 	logMessage := "AEOrdering::checkOrderedJob";
-    AsyncLogger::log(Logger::Information, "AEOrdering", logMessage);
+    Logger::log(Logger::Information, "AEOrdering", logMessage);
     
     // verify that all the jobs have been reported to verification
     verificationAuditEvents:= find _TEST_Req_IF_Verification_audit_event();
@@ -378,7 +378,7 @@ jobId4 : string := "95a3b3a7-fada-41d5-b7e2-902079e81004";
 begin
         
 	logMessage := "AEOrdering::checkOutOrderedJob";
-    AsyncLogger::log(Logger::Information, "AEOrdering", logMessage);
+    Logger::log(Logger::Information, "AEOrdering", logMessage);
     
     inProgressJob := find_one InProgressJob(jobId = jobId1);
 	Assertions::assertTrue((inProgressJob /= null), "Test Out of Order Job: Failed to find Failed Job 1");
@@ -472,7 +472,7 @@ jobId1 : string := "95a3b3a7-fada-41d5-b7e2-902079e81001";
 begin
         
 	logMessage := "AEOrdering::checkReverseOrderedJob";
-    AsyncLogger::log(Logger::Information, "AEOrdering", logMessage);
+    Logger::log(Logger::Information, "AEOrdering", logMessage);
     
     inProgressJob := find_one InProgressJob(jobId = jobId1);
     Assertions::assertTrue((inProgressJob /= null), "Test Reverse Order Job: Failed to find Failed Job");
@@ -515,12 +515,12 @@ jobId3 : string := "95a3b3a7-fada-41d5-b7e2-902079e81003";
 begin
 	
 	logMessage := "AEOrdering::testInvalidJobDefinition";
-	AsyncLogger::log(Logger::Information, "AEOrdering", logMessage);
+	Logger::log(Logger::Information, "AEOrdering", logMessage);
 	AEOrdering::clearDomain(true, false);
 	
 	// Test 1 report an event invalid node
 	logMessage := "AEOrdering::testInvalidJobDefinition - Test invalid job definiton";
-	AsyncLogger::log(Logger::Information, "AEOrdering", logMessage);
+	Logger::log(Logger::Information, "AEOrdering", logMessage);
 	auditEventTime := timestamp'now;
 	AEOrdering::AcceptEvent(jobId1, "jobId1", "NoEvent", "1", auditEventTime'image, emptyPrevEventIds, auditEventData);	
 	
@@ -571,7 +571,7 @@ jobId3 : string := "95a3b3a7-fada-41d5-b7e2-902079e81003";
 begin
 	
 	logMessage := "AEOrdering::testJobComplete";
-	AsyncLogger::log(Logger::Information, "AEOrdering", logMessage);
+	Logger::log(Logger::Information, "AEOrdering", logMessage);
 	AEOrdering::clearDomain(true, false);
 
 	auditEventTime := timestamp'now;
@@ -691,7 +691,7 @@ jobId4 : string := "95a3b3a7-fada-41d5-b7e2-902079e81004";
 begin
 	
 	logMessage := "AEOrdering::testJobFailure";
-	AsyncLogger::log(Logger::Information, "AEOrdering", logMessage);
+	Logger::log(Logger::Information, "AEOrdering", logMessage);
 	AEOrdering::clearDomain(true, false);
 	delete (find _TEST_Req_IF_Verification_audit_event());
 	delete (find _TEST_Req_IF_Verification_failedJob());
@@ -833,7 +833,7 @@ jobId1 : string := "95a3b3a7-fada-41d5-b7e2-902079e81001";
 begin
 	
 	logMessage := "AEOrdering::testOrderedJob";
-	AsyncLogger::log(Logger::Information, "AEOrdering", logMessage);
+	Logger::log(Logger::Information, "AEOrdering", logMessage);
 	AEOrdering::clearDomain(true, false);
 	
 	auditEventTime := timestamp'now;
@@ -889,7 +889,7 @@ jobId4 : string := "95a3b3a7-fada-41d5-b7e2-902079e81004";
 begin
 	
 	logMessage := "AEOrdering::testOrderedJob";
-	AsyncLogger::log(Logger::Information, "AEOrdering", logMessage);
+	Logger::log(Logger::Information, "AEOrdering", logMessage);
 	AEOrdering::clearDomain(true, false);
 	delete (find _TEST_Req_IF_Verification_audit_event());
 	
@@ -1277,7 +1277,7 @@ jobId1 : string := "95a3b3a7-fada-41d5-b7e2-902079e81001";
 begin
 	
 	logMessage := "AEOrdering::testReverseOrderedJob";
-	AsyncLogger::log(Logger::Information, "AEOrdering", logMessage);
+	Logger::log(Logger::Information, "AEOrdering", logMessage);
 	verificationAuditEvents:= find _TEST_Req_IF_Verification_audit_event();
 	delete verificationAuditEvents;
 	AEOrdering::clearDomain(true, false);
@@ -1484,7 +1484,7 @@ jobName : string := "AEOrdering-Test";
 begin
 	
 	logMessage := "AEOrdering::fork and merge";
-	AsyncLogger::log(Logger::Information, "AEOrdering", logMessage);
+	Logger::log(Logger::Information, "AEOrdering", logMessage);
 	AEOrdering::clearDomain(true, false);
 	
 	auditEventTime := timestamp'now;
@@ -1609,7 +1609,7 @@ jobId2 : string := "95a3b3a7-fada-41d5-b7e2-902079e81002";
 begin
 	
 	logMessage := "AEOrdering::testOrderedJobWithData";
-	AsyncLogger::log(Logger::Information, "AEOrdering", logMessage);
+	Logger::log(Logger::Information, "AEOrdering", logMessage);
 	delete find _TEST_Req_IF_Verification_failedJob();
 	AEOrdering::clearDomain(true, false);
 	
@@ -1650,7 +1650,7 @@ begin
 	// verify the audit event data
 	verificationAuditEvent := find_one _TEST_Req_IF_Verification_audit_event(auditEventId = "1");
     Assertions::assertTrue((verificationAuditEvent /= null), "Test Ordered Job: Failed to find` verification audit event id = 1");
-	AsyncLogger::log(Logger::Information, "AEOrdering", "verification audit event length: " & verificationAuditEvent.reportableAuditEventDataItems'length'image);
+	Logger::log(Logger::Information, "AEOrdering", "verification audit event length: " & verificationAuditEvent.reportableAuditEventDataItems'length'image);
     Assertions::assertTrue((verificationAuditEvent.reportableAuditEventDataItems'length = 2), "Test Ordered Job With Data: Failed as verification audit event data Items /= 2");
     for dataItem in verificationAuditEvent.reportableAuditEventDataItems loop
 	    if dataItem.dataName = "Data1" then
@@ -1779,7 +1779,7 @@ systemSpec : instance of SystemSpec;
 begin
 	
 	logMessage := "AEOrdering::testLaneValidation";
-	AsyncLogger::log(Logger::Information, "AEOrdering", logMessage);
+	Logger::log(Logger::Information, "AEOrdering", logMessage);
     verificationAuditEvents:= find _TEST_Req_IF_Verification_audit_event();
 	delete verificationAuditEvents;
 	AEOrdering::clearDomain(true, false);

--- a/models/AEReception/models/AEReception/AERdomain/AEReception/AERclasses/Reception/InstanceStateMachine/InstanceStateMachine.masl
+++ b/models/AEReception/models/AEReception/AERdomain/AEReception/AERclasses/Reception/InstanceStateMachine/InstanceStateMachine.masl
@@ -22,7 +22,7 @@ begin
     if this.jsonObject'keys'length = 1 and this.jsonObject'keys'any = "__comment__" then
         // ignore comment objects
         logMessage := "AEReception::Reception.receiving_audit_event : JSON comment: " & JSON::get_string(this.jsonObject[this.jsonObject'keys'any]);
-        AsyncLogger::log(Logger::Debug, "AEReception", "JSON comment: " & JSON::get_string(this.jsonObject[this.jsonObject'keys'any]));
+        Logger::log(Logger::Debug, "AEReception", "JSON comment: " & JSON::get_string(this.jsonObject[this.jsonObject'keys'any]));
     else
         // report the event received
         if this.jsonObject'contains("eventId") then
@@ -46,7 +46,7 @@ begin
 				eventContent := "EventId = " & eventId;
 				Reporting~>reportEvent(Logger::Error, "reception_event_invalid", eventContent);
 				logMessage := "AEReception::Reception.receiving_audit_event : Dropping invalid event with ID: " & eventId & "\n" & JSON::dump(validation_result, true);
-				AsyncLogger::log(Logger::Debug, "AEReception", logMessage);
+				Logger::log(Logger::Debug, "AEReception", logMessage);
 			end if;
 		end if;
 
@@ -136,7 +136,7 @@ begin
         generate Reception.ready_for_event() to this;
     else
         logMessage := "AEReception::Reception.parsing : Incorrect JSON format : " & auditEvent;
-        AsyncLogger::log(Logger::Error, "AEReception", logMessage);
+        Logger::log(Logger::Error, "AEReception", logMessage);
 		eventContent := "FailureReason = Incorrect JSON format = " & auditEvent;;
 		Reporting~>reportEvent(Logger::Error, "reception_file_process_error", eventContent);
         generate Reception.parse_failed() to this;
@@ -146,14 +146,14 @@ exception
 
     when JSON::JSONException =>
 	   logMessage := "AEReception::Reception.parsing : Failed to parse JSON : " & auditEvent;
-	   AsyncLogger::log(Logger::Error, "AEReception", logMessage);
+	   Logger::log(Logger::Error, "AEReception", logMessage);
 		eventContent := "FailureReason = Failed to parse JSON = " & auditEvent;;
 		Reporting~>reportEvent(Logger::Error, "reception_file_process_error", eventContent);
 	   generate Reception.parse_failed() to this;
 	   
 	when others =>
 	   logMessage := "AEReception::Reception.parsing : Could not process audit events : " & auditEvent;
-	   AsyncLogger::log(Logger::Error, "AEReception", logMessage);
+	   Logger::log(Logger::Error, "AEReception", logMessage);
 	   generate Reception.parse_failed() to this;
 
 end state;

--- a/models/AEReception/models/AEReception/AERdomain/AEReception/AERclasses/ReceptionSpec/InstanceStateMachine/InstanceStateMachine.masl
+++ b/models/AEReception/models/AEReception/AERdomain/AEReception/AERclasses/ReceptionSpec/InstanceStateMachine/InstanceStateMachine.masl
@@ -42,7 +42,7 @@ begin
 			end if;
     	else
 			logMessage := "AEReception::ReceptionSpec.ConfigurationLoaded : Config file invalid:\n" & JSON::dump(configValidationResult, true);
-			AsyncLogger::log(Logger::Debug, "AEReception", logMessage);
+			Logger::log(Logger::Debug, "AEReception", logMessage);
 			raise JSON::JSONException("Config file invalid");
 		end if;
 		
@@ -57,7 +57,7 @@ begin
 		schedule this.configTimer generate ReceptionSpec.checkConfigUpdate() to this delay this.specUpdateRate;
 	else
 		logMessage := "AEReception::ReceptionSpec.ConfigurationLoaded : failed to locate config file. Specified file = " & this.configFilePath & this.configFile;
-		AsyncLogger::log(Logger::Error, "AEReception", logMessage);
+		Logger::log(Logger::Error, "AEReception", logMessage);
 		raise program_error;
 	end if;
 	
@@ -67,7 +67,7 @@ exception
 	when others => 	
 	
 		logMessage := "AEReception::ReceptionSpec.ConfigurationLoaded : failed to load configuration file";
-		AsyncLogger::log(Logger::Error, "AEReception", logMessage);
+		Logger::log(Logger::Error, "AEReception", logMessage);
 		raise program_error;
 		
 end state;
@@ -89,7 +89,7 @@ begin
 		end if;
 		else
 		logMessage := "AEReception::ReceptionSpec.ConfigChecked : failed to locate config file. Specified file = " & this.configFilePath & this.configFile;
-		AsyncLogger::log(Logger::Error, "AEReception", logMessage);
+		Logger::log(Logger::Error, "AEReception", logMessage);
 		raise program_error;
 	end if;
 	
@@ -104,7 +104,7 @@ exception
 	when others => 	
 	
 		logMessage := "AEReception::ReceptionSpec.ConfigChecked : failed to load configuration file";
-		AsyncLogger::log(Logger::Error, "AEReception", logMessage);
+		Logger::log(Logger::Error, "AEReception", logMessage);
 		raise program_error;		
 	
 end state;

--- a/models/AEReception/models/AEReception/AERdomain/AEReception/AEReception.masl
+++ b/models/AEReception/models/AEReception/AERdomain/AEReception/AEReception.masl
@@ -3,7 +3,7 @@ public service AEReception::Reporting~>reportEvent ( eventPriority : in Logger::
                                                     eventLabel : in string,
                                                     eventContent : in string ) is
 begin
-	AsyncLogger::log(eventPriority, "Reception", eventLabel & " : " & eventContent);
+	Logger::log(eventPriority, "Reception", eventLabel & " : " & eventContent);
 end service;
 //! ACTIVITY END. DO NOT EDIT THIS LINE.
 

--- a/models/AEReception/models/AEReception/AERdomain/AEReception/scenarios/scenarios.masl
+++ b/models/AEReception/models/AEReception/AERdomain/AEReception/scenarios/scenarios.masl
@@ -20,7 +20,7 @@ begin
 		generate ReceptionSpec.loadConfig() to receptionSpec;
 	else
 		logMessage := "AEReception::init : failed to locate config file. Specified file = " & configFilePath & configFile;
-		AsyncLogger::log(Logger::Information, "AEReception", logMessage);
+		Logger::log(Logger::Information, "AEReception", logMessage);
 		raise program_error;
 	end if;
 
@@ -28,7 +28,7 @@ exception
 	when others =>
 	
 		logMessage := "AEReception::init : failed during start up";
-		AsyncLogger::log(Logger::Error, "AEReception", logMessage);
+		Logger::log(Logger::Error, "AEReception", logMessage);
 		raise program_error;
 	
 end service;

--- a/models/FileReception/models/FileReception/FRdomain/FReception/FRclasses/FileControl/InstanceStateMachine/InstanceStateMachine.masl
+++ b/models/FileReception/models/FileReception/FRdomain/FReception/FRclasses/FileControl/InstanceStateMachine/InstanceStateMachine.masl
@@ -33,7 +33,7 @@ begin
 					generate FileControl.allocateFile(eventFile) to this;
 					fileAssigned := true;
 					logMessage := "FileReception::FileControl.WaitingForFile : assigning file " & eventFile.fileName;
-					AsyncLogger::log(Logger::Debug, "FileReception", logMessage);
+					Logger::log(Logger::Debug, "FileReception", logMessage);
 					exit; // for loop
 				end if;
 			end if;

--- a/models/FileReception/models/FileReception/FRdomain/FReception/FRclasses/FileReceptionSpec/InstanceStateMachine/InstanceStateMachine.masl
+++ b/models/FileReception/models/FileReception/FRdomain/FReception/FRclasses/FileReceptionSpec/InstanceStateMachine/InstanceStateMachine.masl
@@ -51,7 +51,7 @@ begin
 			end if;
     	else
 			logMessage := "AEReception::ReceptionSpec.ConfigurationLoaded : Config file invalid:\n" & JSON::dump(configValidationResult, true);
-			AsyncLogger::log(Logger::Debug, "AEReception", logMessage);
+			Logger::log(Logger::Debug, "AEReception", logMessage);
 			raise JSON::JSONException("Config file invalid");
 		end if;
 
@@ -64,7 +64,7 @@ begin
 		schedule this.configTimer generate FileReceptionSpec.checkConfigUpdate() to this delay this.specUpdateRate;
 	else
 		logMessage := "FileReception::FileReceptionSpec.ConfigurationLoaded : failed to locate config file. Specified file = " & this.configFilePath & this.configFile;
-		AsyncLogger::log(Logger::Error, "FileReception", logMessage);
+		Logger::log(Logger::Error, "FileReception", logMessage);
 		raise program_error;
 	end if;
 	
@@ -95,7 +95,7 @@ exception
 	when others => 	
 	
 		logMessage := "FileReception::FileReceptionSpec.ConfigurationLoaded : failed to load configuration file";
-		AsyncLogger::log(Logger::Error, "FileReception", logMessage);
+		Logger::log(Logger::Error, "FileReception", logMessage);
 		raise program_error;
 		
 end state;
@@ -117,7 +117,7 @@ begin
 		end if;
 		else
 		logMessage := "FileReception::FileReceptionSpec.ConfigChecked : failed to locate config file. Specified file = " & this.configFilePath & this.configFile;
-		AsyncLogger::log(Logger::Error, "FileReception", logMessage);
+		Logger::log(Logger::Error, "FileReception", logMessage);
 		raise program_error;
 	end if;
 	
@@ -125,7 +125,7 @@ exception
 	when others => 	
 	
 		logMessage := "FileReception::FileReceptionSpec.ConfigChecked : failed to load configuration file";
-		AsyncLogger::log(Logger::Error, "FileReception", logMessage);
+		Logger::log(Logger::Error, "FileReception", logMessage);
 		raise program_error;		
 	
 end state;

--- a/models/FileReception/models/FileReception/FRdomain/FReception/FReception.masl
+++ b/models/FileReception/models/FileReception/FRdomain/FReception/FReception.masl
@@ -3,7 +3,7 @@ public service FReception::Reporting~>reportEvent ( eventPriority : in Logger::P
                                                    eventLabel : in string,
                                                    eventContent : in string ) is
 begin
-	AsyncLogger::log(eventPriority, "Reception", eventLabel & " : " & eventContent);
+	Logger::log(eventPriority, "Reception", eventLabel & " : " & eventContent);
 end service;
 //! ACTIVITY END. DO NOT EDIT THIS LINE.
 

--- a/models/FileReception/models/FileReception/FRdomain/FReception/scenarios/scenarios.masl
+++ b/models/FileReception/models/FileReception/FRdomain/FReception/scenarios/scenarios.masl
@@ -20,7 +20,7 @@ begin
 		generate FileReceptionSpec.loadConfig() to fileReceptionSpec;
 	else
 		logMessage := "FileReception::init : failed to locate config file. Specified file = " & configFilePath & configFile;
-		AsyncLogger::log(Logger::Information, "FileReception", logMessage);
+		Logger::log(Logger::Information, "FileReception", logMessage);
 		raise program_error;
 	end if;
 
@@ -28,7 +28,7 @@ exception
 	when others =>
 	
 		logMessage := "FileReception::init : failed during start up";
-		AsyncLogger::log(Logger::Error, "FileReception", logMessage);
+		Logger::log(Logger::Error, "FileReception", logMessage);
 		raise program_error;
 	
 end service;

--- a/models/InvariantStore/models/InvariantStore/ISdomain/IStore/IStoreClasses/InvStore/InstanceStateMachine/InstanceStateMachine.masl
+++ b/models/InvariantStore/models/InvariantStore/ISdomain/IStore/IStoreClasses/InvStore/InstanceStateMachine/InstanceStateMachine.masl
@@ -88,7 +88,7 @@ begin
 exception
 	when others => 
 		logMessage := "IStore::InvStore.StoreLoaded : failed to load invariant store";
-		AsyncLogger::log(Logger::Information, "IStore", logMessage);
+		Logger::log(Logger::Information, "IStore", logMessage);
 		raise program_error;
 		
 end state;
@@ -113,7 +113,7 @@ begin
 			end if;
 		else
 			logMessage := "InvStore.StoreChecked : failed to locate invariant store. Specified file = " & string(this.invStoreName);
-			AsyncLogger::log(Logger::Error, "IStore", logMessage);
+			Logger::log(Logger::Error, "IStore", logMessage);
 			raise program_error;
 		end if;
 	end if;
@@ -122,7 +122,7 @@ exception
 	when others => 	
 	
 		logMessage := "AEOrdering::InvStore.StoreChecked : failed to load invariant store";
-		AsyncLogger::log(Logger::Error, "IStore", logMessage);
+		Logger::log(Logger::Error, "IStore", logMessage);
 		raise program_error;
 	
 end state;

--- a/models/InvariantStore/models/InvariantStore/ISdomain/IStore/scenarios/scenarios.masl
+++ b/models/InvariantStore/models/InvariantStore/ISdomain/IStore/scenarios/scenarios.masl
@@ -33,7 +33,7 @@ exception
 	when others =>
 	
 		logMessage := "IStore::init : failed during start up";
-		AsyncLogger::log(Logger::Error, "IStore", logMessage);
+		Logger::log(Logger::Error, "IStore", logMessage);
 		raise program_error;
 	
 end service;

--- a/models/InvariantStore/models/InvariantStore/ISdomain/IStore/tests/tests.masl
+++ b/models/InvariantStore/models/InvariantStore/ISdomain/IStore/tests/tests.masl
@@ -12,17 +12,17 @@ invariantList : sequence of persistedInvariantStructure;
 begin
 	
 	// check the store and the store file exists
-	AsyncLogger::log(Logger::Information, "IStore", "Running Test01 - Store Exists");
+	Logger::log(Logger::Information, "IStore", "Running Test01 - Store Exists");
 	
 	delete find Invariant();
 	delete find _TEST_StoreClient_addInvariants();
 	Assertions::assertTrue((find InvStore())'length = 1, "Test Invariant Store: wrong number of invariant store, expected 1 found: " & ((find InvStore())'length)'image);
 	invStore := find_one InvStore();
 	Assertions::assertTrue(Filesystem::file_exists(invStore.invStoreName), "Test Invariant Store: invariant store does not exist: " & (invStore.invStoreName));
-	AsyncLogger::log(Logger::Information, "IStore", "Running Test01 - Passed");
+	Logger::log(Logger::Information, "IStore", "Running Test01 - Passed");
 	
 	// make sure that the invariant store is empty
-	AsyncLogger::log(Logger::Information, "IStore", "Running Test02 - Reload Store on Update");
+	Logger::log(Logger::Information, "IStore", "Running Test02 - Reload Store on Update");
 	Filesystem::touch_file(emptyInvaraintFile);
 	Filesystem::move_file(emptyInvaraintFile, invStore.invStoreName);
 	delay duration'milliseconds(100); // short delay to make sure the modification time changes
@@ -33,10 +33,10 @@ begin
 	generate InvStore.checkStore() to invStore;
 	Test::service_event_queue();
 	Assertions::assertTrue(currentStoredModificationTime /= invStore.storeModificationTime, "Test Invariant Store: invariant store file was not re-read: " & (invStore.invStoreName));
-	AsyncLogger::log(Logger::Information, "IStore", "Running Test02 - Passed");
+	Logger::log(Logger::Information, "IStore", "Running Test02 - Passed");
 	
 	// move the test invariant store into place
-	AsyncLogger::log(Logger::Information, "IStore", "Running Test03 - Reload Store containing invariants");
+	Logger::log(Logger::Information, "IStore", "Running Test03 - Reload Store containing invariants");
 	delay duration'milliseconds(100); // short delay to make sure the modification time changes
 	Filesystem::copy_file(testFile, tmpFile);
 	Filesystem::move_file(tmpFile, invStore.invStoreName);
@@ -53,10 +53,10 @@ begin
 	Assertions::assertTrue(reportedInvariants'length = 1, "Test Invariant Store: Invariants not reported to client");
 	invariantList := reportedInvariants'any.invariantsToReport;
 	Assertions::assertTrue(invariantList'length = 2, "Test Invariant Store: Expected 2 invariants to be reported to client found: " &invariantList'length'image);
-	AsyncLogger::log(Logger::Information, "IStore", "Running Test03 - Passed");
+	Logger::log(Logger::Information, "IStore", "Running Test03 - Passed");
 	
 	// add an invariant
-	AsyncLogger::log(Logger::Information, "IStore", "Running Test04 - Add invariants");
+	Logger::log(Logger::Information, "IStore", "Running Test04 - Add invariants");
 	IStore::persistInvariant("inv3", "11111", timestamp'now, timestamp'now + @PT10M@, "Job2", "Event3", 0);
 	Test::service_event_queue();
 	Assertions::assertTrue((find Invariant())'length = 3, "Test Invariant Store: Expected 3 invariants found: " & (find Invariant())'length'image);
@@ -76,10 +76,10 @@ begin
 	Assertions::assertTrue(reportedInvariants'length = 1, "Test Invariant Store: Invariants not reported to client");
 	invariantList := reportedInvariants'any.invariantsToReport;
 	Assertions::assertTrue(invariantList'length = 3, "Test Invariant Store: Expected 3 invariants to be reported to client found: " &invariantList'length'image);
-	AsyncLogger::log(Logger::Information, "IStore", "Running Test04 - Passed");
+	Logger::log(Logger::Information, "IStore", "Running Test04 - Passed");
 	
 	// add an invariant that will expire
-	AsyncLogger::log(Logger::Information, "IStore", "Running Test05 - Expired invariants");
+	Logger::log(Logger::Information, "IStore", "Running Test05 - Expired invariants");
 	IStore::persistInvariant("inv4", "99999", timestamp'now, timestamp'now + @PT1S@, "Job2", "Event4", 0);
 	Test::service_event_queue();
 	Assertions::assertTrue((find Invariant())'length = 4, "Test Invariant Store: Expected 4 invariants found: " & (find Invariant())'length'image);
@@ -98,20 +98,20 @@ begin
 	Assertions::assertTrue(reportedInvariants'length = 1, "Test Invariant Store: Invariants not reported to client");
 	invariantList := reportedInvariants'any.invariantsToReport;
 	Assertions::assertTrue(invariantList'length = 3, "Test Invariant Store: Expected 3 invariants to be reported to client found: " &invariantList'length'image);
-	AsyncLogger::log(Logger::Information, "IStore", "Running Test05 - Passed");
+	Logger::log(Logger::Information, "IStore", "Running Test05 - Passed");
 	
 	// request an invariant that the store knows about is restored
-	AsyncLogger::log(Logger::Information, "IStore", "Running Test06 - Recover known invariant");
+	Logger::log(Logger::Information, "IStore", "Running Test06 - Recover known invariant");
 	delete reportedInvariants;
 	IStore::restoreNamedInvariant("inv1", "11111");
 	Test::service_event_queue();
 	reportedInvariants := find _TEST_StoreClient_addInvariants();
 	Assertions::assertTrue(reportedInvariants'length = 1, "Test Invariant Store: Invariants not reported to client");
 	Assertions::assertTrue(find_one Invariant(invariantName = "inv1") /= null, "Test Invariant Store: Failed to find invariant inv1");
-	AsyncLogger::log(Logger::Information, "IStore", "Running Test06 - Passed");
+	Logger::log(Logger::Information, "IStore", "Running Test06 - Passed");
 
 	// request an invariant that the store does not know about is restored
-	AsyncLogger::log(Logger::Information, "IStore", "Running Test07 - Recover unknown invariant");
+	Logger::log(Logger::Information, "IStore", "Running Test07 - Recover unknown invariant");
 	delete (find Invariant(invariantName = "inv1"));
 	delete reportedInvariants;
 	IStore::restoreNamedInvariant("inv1", "11111");
@@ -119,7 +119,7 @@ begin
 	reportedInvariants := find _TEST_StoreClient_addInvariants();
 	Assertions::assertTrue(reportedInvariants'length = 1, "Test Invariant Store: Invariants not reported to client");
 	Assertions::assertTrue(find_one Invariant(invariantName = "inv1") /= null, "Test Invariant Store: Failed to find invariant inv1");
-	AsyncLogger::log(Logger::Information, "IStore", "Running Test07 - Passed");
+	Logger::log(Logger::Information, "IStore", "Running Test07 - Passed");
 
 
 

--- a/models/SequenceVerificationDataCentric/models/SequenceVerificationDataCentric/SVDCdomain/AESequenceDC/AESequenceDC.masl
+++ b/models/SequenceVerificationDataCentric/models/SequenceVerificationDataCentric/SVDCdomain/AESequenceDC/AESequenceDC.masl
@@ -18,7 +18,7 @@ logMessage : string;
 begin
 
   logMessage := "AESequenceDC::Persistence_Req_IF~>PersistInvariant : PERSISTENCE: The Extra-Job Invariant " & extraJobInvariantName & " with value = " & invariantValue & " has been saved to the persistence service";
-  AsyncLogger::log(Logger::Information, "AESequenceDC", logMessage);
+  Logger::log(Logger::Information, "AESequenceDC", logMessage);
 
 end service;
 //! ACTIVITY END. DO NOT EDIT THIS LINE.
@@ -31,7 +31,7 @@ logMessage : string;
 begin
 
   logMessage := "AESequenceDC::Persistence_Req_IF~>PersistInvariant : PERSISTENCE: The Extra-Job Invariant " & extraJobInvariantName & " with value = " & invariantValue & " has been requested from the persistence service";
-  AsyncLogger::log(Logger::Information, "AESequenceDC", logMessage);
+  Logger::log(Logger::Information, "AESequenceDC", logMessage);
   
 end service;
 //! ACTIVITY END. DO NOT EDIT THIS LINE.
@@ -41,7 +41,7 @@ public service AESequenceDC::Reporting~>reportEvent ( eventPriority : in Logger:
                                                      eventLabel : in string,
                                                      eventContent : in string ) is
 begin
-	AsyncLogger::log(eventPriority, "Verifier", eventLabel & " : " & eventContent);
+	Logger::log(eventPriority, "Verifier", eventLabel & " : " & eventContent);
 end service;
 //! ACTIVITY END. DO NOT EDIT THIS LINE.
 

--- a/models/SequenceVerificationDataCentric/models/SequenceVerificationDataCentric/SVDCdomain/AESequenceDC/SVDCclasses/DynamicControlDefinition/DynamicControlDefinition.masl
+++ b/models/SequenceVerificationDataCentric/models/SequenceVerificationDataCentric/SVDCdomain/AESequenceDC/SVDCclasses/DynamicControlDefinition/DynamicControlDefinition.masl
@@ -54,28 +54,28 @@ begin
         else
           // Error handling for the specified Audit Event Occurrence Definition was not found
           logMessage := "AESequenceDC::DynamicControlDefinition.createDynamicControlDefinition : There is no known Audit Event Occurrence Definition with Audit Event Definition name " & sourceEventType & " Occurrence Id " & sourceOccurrenceId'image & " corresponding to the source event specified for Dynamic Control Definition";
-	      AsyncLogger::log(Logger::Error, "AESequenceDC", logMessage);
+	      Logger::log(Logger::Error, "AESequenceDC", logMessage);
 		  eventContent := "FailureReason = There is no known Audit Event Occurrence Definition with Audit Event Definition name corresponding to the source event specified for Dynamic Control Definition" & " : EventType = " & sourceEventType & " : Occurrence Id = " & sourceOccurrenceId'image;
 		  Reporting~>reportEvent(Logger::Error, "svdc_job_definition_failed", eventContent);
         end if;  
       else
         // Error handling for the Sequence Definition corresponding to this Audit Event was not found
         logMessage := "AESequenceDC::DynamicControlDefinition.createDynamicControlDefinition : There is no known Sequence Definition associated with Audit Event Definition named " & sourceEventType & " corresponding to the source event specified for Dynamic Control Definition";
-	    AsyncLogger::log(Logger::Error, "AESequenceDC", logMessage);
+	    Logger::log(Logger::Error, "AESequenceDC", logMessage);
 	    eventContent := "FailureReason = There is no known Sequence Definition associated with Audit Event Definition named corresponding to the source event specified for Dynamic Control Definition" & "EventType = " & sourceEventType;
 		Reporting~>reportEvent(Logger::Error, "svdc_job_definition_failed", eventContent);
       end if;    
     else
       // Error handling for the sourceEventType specified is invalid
       logMessage := "AESequenceDC::DynamicControlDefinition.createDynamicControlDefinition : There is no known Audit Event Definition with name " & sourceEventType & " corresponding to the source event specified for Dynamic Control Definition";
-	  AsyncLogger::log(Logger::Error, "AESequenceDC", logMessage);
+	  Logger::log(Logger::Error, "AESequenceDC", logMessage);
 	  eventContent := "FailureReason = There is no known Audit Event Definition with name corresponding to the source event specified for Dynamic Control Definition" & " : EventType = " & sourceEventType;
 	  Reporting~>reportEvent(Logger::Error, "svdc_job_definition_failed", eventContent);
     end if;    
   else
     // Error handling for Error Job Definition Unknown
     logMessage := "AESequenceDC::DynamicControlDefinition.createDynamicControlDefinition : There is no known Job Definition with name " & jobName & " corresponding to the source event specified for Dynamic Control Definition";
-	AsyncLogger::log(Logger::Error, "AESequenceDC", logMessage);
+	Logger::log(Logger::Error, "AESequenceDC", logMessage);
 	eventContent := "FailureReason = There is no known Job Definition with name corresponding to the source event specified for Dynamic Control Definition" & " :JobName = " & jobName;
 	Reporting~>reportEvent(Logger::Error, "svdc_job_definition_failed", eventContent);
     
@@ -123,21 +123,21 @@ begin
         else
           // Error handling for the specified Audit Event Occurrence Definition was not found
           logMessage := "AESequenceDC::DynamicControlDefinition.linkUserEventDefn : There is no known Audit Event Occurrence Definition with Audit Event Definition name " & userEventType & " Occurrence Id " & userOccurrenceId'image & " corresponding to the user event specified for Dynamic Control Definition";
-	      AsyncLogger::log(Logger::Error, "AESequenceDC", logMessage);
+	      Logger::log(Logger::Error, "AESequenceDC", logMessage);
 		  eventContent := "FailureReason = There is no known Audit Event Occurrence Definition with Audit Event Definition name corresponding to the user event specified for Dynamic Control Definition" & " : EventType = " & userEventType & " : Occurrence Id = " & userOccurrenceId'image;
 		  Reporting~>reportEvent(Logger::Error, "svdc_job_definition_failed", eventContent);
         end if;  
       else
         // Error handling for the Sequence Definition corresponding to this Audit Event was not found
         logMessage := "AESequenceDC::DynamicControlDefinition.linkUserEventDefn : There is no known Sequence Definition associated with Audit Event Definition named " & userEventType & " corresponding to the user event specified for Dynamic Control Definition";
-	    AsyncLogger::log(Logger::Error, "AESequenceDC", logMessage);
+	    Logger::log(Logger::Error, "AESequenceDC", logMessage);
 		eventContent := "FailureReason = There is no known Sequence Definition associated with Audit Event Definition named corresponding to the user event specified for Dynamic Control Definition" & " : EventType = " & userEventType;
 		Reporting~>reportEvent(Logger::Error, "svdc_job_definition_failed", eventContent);
       end if;    
     else
       // Error handling for the userEventType specified is invalid
       logMessage := "AESequenceDC::DynamicControlDefinition.linkUserEventDefn : There is no known Audit Event Definition with name " & userEventType & " corresponding to the user event specified for Dynamic Control Definition";
-	  AsyncLogger::log(Logger::Error, "AESequenceDC", logMessage);
+	  Logger::log(Logger::Error, "AESequenceDC", logMessage);
 	  eventContent := "FailureReason = There is no known Audit Event Definition with name corresponding to the user event specified for Dynamic Control Definition" & " : EventType = " & userEventType;
 	  Reporting~>reportEvent(Logger::Error, "svdc_job_definition_failed", eventContent);
     end if;    
@@ -145,7 +145,7 @@ begin
   else
     //Error handling for the specified Dynamic Control Definition instance was not found
     logMessage := "AESequenceDC::DynamicControlDefinition.linkUserEventDefn : There is no known Job Definition with name " & jobName & " corresponding to the user event specified for Dynamic Control Definition";
-	AsyncLogger::log(Logger::Error, "AESequenceDC", logMessage);
+	Logger::log(Logger::Error, "AESequenceDC", logMessage);
 	eventContent := "FailureReason = There is no known Job Definition with name corresponding to the user event specified for Dynamic Control Definition" & " : JobName = " & jobName;
 	Reporting~>reportEvent(Logger::Error, "svdc_job_definition_failed", eventContent);
   end if;

--- a/models/SequenceVerificationDataCentric/models/SequenceVerificationDataCentric/SVDCdomain/AESequenceDC/SVDCclasses/ExtraJobInvariantDefn/ExtraJobInvariantDefn.masl
+++ b/models/SequenceVerificationDataCentric/models/SequenceVerificationDataCentric/SVDCdomain/AESequenceDC/SVDCclasses/ExtraJobInvariantDefn/ExtraJobInvariantDefn.masl
@@ -48,25 +48,25 @@ begin
           link theInvariant R20 theEventOccInSeqDefn;
         else
           logMessage := "AESequenceDC::ExtraJobInvariantDefn.createSourceExtraJobInvariantDefn : Invalid Event Definition provided (type 3) : " & invariantEventDefn.eventTypeName & "for Extra Job Invariant Name = " & invariantName;
-	      AsyncLogger::log(Logger::Error, "AESequenceDC", logMessage);
+	      Logger::log(Logger::Error, "AESequenceDC", logMessage);
 	      eventContent := "FailureReason = Invalid Event Definition provided for Extra Job Invariant Name" & " : EventType = " & invariantEventDefn.eventTypeName & " : InvariantName = " & invariantName;
 	      Reporting~>reportEvent(Logger::Error, "svdc_job_definition_failed", eventContent);        
         end if;  
       else
           logMessage := "AESequenceDC::ExtraJobInvariantDefn.createSourceExtraJobInvariantDefn : Invalid Event Definition provided (type 2) : " & invariantEventDefn.eventTypeName & "for Extra Job Invariant Name = " & invariantName;
-	      AsyncLogger::log(Logger::Error, "AESequenceDC", logMessage);
+	      Logger::log(Logger::Error, "AESequenceDC", logMessage);
 	      eventContent := "FailureReason = Invalid Event Definition provided for Extra Job Invariant Name" & " : EventType = " & invariantEventDefn.eventTypeName & " : InvariantName = " & invariantName;
 	      Reporting~>reportEvent(Logger::Error, "svdc_job_definition_failed", eventContent);              
       end if;
     else
       logMessage := "AESequenceDC::ExtraJobInvariantDefn.createSourceExtraJobInvariantDefn : Invalid Event Definition provided (type 1) : " & invariantEventDefn.eventTypeName & "for Extra Job Invariant Name = " & invariantName;
-	  AsyncLogger::log(Logger::Error, "AESequenceDC", logMessage);
+	  Logger::log(Logger::Error, "AESequenceDC", logMessage);
 	  eventContent := "FailureReason = Invalid Event Definition provided for Extra Job Invariant Name" & " : EventType = " & invariantEventDefn.eventTypeName & " : InvariantName = " & invariantName;
 	  Reporting~>reportEvent(Logger::Error, "svdc_job_definition_failed", eventContent);
 	end if;              
   else
     logMessage := "AESequenceDC::ExtraJobInvariantDefn.createSourceExtraJobInvariantDefn : Invalid Job Definition provided : " & jobDefnName & "for Extra Job Invariant Name = " & invariantName;
-	AsyncLogger::log(Logger::Error, "AESequenceDC", logMessage);
+	Logger::log(Logger::Error, "AESequenceDC", logMessage);
 	eventContent := "FailureReason = Invalid Job Definition provided for Extra Job Invariant Name" & " : JobName = " & jobDefnName & " : InvariantName = " & invariantName;
 	Reporting~>reportEvent(Logger::Error, "svdc_job_definition_failed", eventContent);
   end if;
@@ -108,13 +108,13 @@ begin
       link theInvariantDefn R21 theEventOccInSeqDefn;
     else
       logMessage := "AESequenceDC::ExtraJobInvariantDefn.linkUserExtraJobInvariantDefn : Invalid Event Definition provided : " & invariantEventDefn.eventTypeName & "for Extra Job Invariant Name = " & invariantName;
-	  AsyncLogger::log(Logger::Error, "AESequenceDC", logMessage);
+	  Logger::log(Logger::Error, "AESequenceDC", logMessage);
 	  eventContent := "FailureReason = Invalid Event Definition provided for Extra Job Invariant Name" & " : EventType = " & invariantEventDefn.eventTypeName & " : InvariantName = " & invariantName;
 	  Reporting~>reportEvent(Logger::Error, "svdc_job_definition_failed", eventContent);
 	end if;              
   else
     logMessage := "AESequenceDC::ExtraJobInvariantDefn.linkUserExtraJobInvariantDefn : Invalid Job Definition provided : " & jobDefnName & "for Extra Job Invariant Name = " & invariantName;
-	AsyncLogger::log(Logger::Error, "AESequenceDC", logMessage);
+	Logger::log(Logger::Error, "AESequenceDC", logMessage);
 	eventContent := "FailureReason = Invalid Job Definition provided for Extra Job Invariant Name" & " : EventType = " & invariantEventDefn.eventTypeName & " : InvariantName = " & invariantName;
 	Reporting~>reportEvent(Logger::Error, "svdc_job_definition_failed", eventContent);
   end if;  
@@ -182,14 +182,14 @@ begin
   	       else
   	              
              logMessage := "AESequenceDC::ExtraJobInvariantDefn.restoreInvariantOfThisDefinition : Something went wrong restoring the Extra-Job Invariant's state " & restoredInvariant.invariantName;
-             AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+             Logger::log(Logger::Debug, "AESequenceDC", logMessage);
   	                                                          
   	       end if; 
   	       
   	     else
   	     
              logMessage := "AESequenceDC::ExtraJobInvariantDefn.restoreInvariantOfThisDefinition : The restored Extra-Job Invariant is already present in the cache " & restoredInvariant.invariantName;
-             AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+             Logger::log(Logger::Debug, "AESequenceDC", logMessage);
   	     
   	     end if;  
 
@@ -200,14 +200,14 @@ begin
          else
                   
            logMessage := "AESequenceDC::ExtraJobInvariantDefn.restoreInvariantOfThisDefinition : The Extra-Job Invariant has not been restored successfully " & restoredInvariant.invariantName;
-           AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+           Logger::log(Logger::Debug, "AESequenceDC", logMessage);
   	                                                          
          end if;  
                 
        else
                 
          logMessage := "AESequenceDC::ExtraJobInvariantDefn.restoreInvariantOfThisDefinition : The Extra-Job Invariant to be restored does not match any known definition " & restoredInvariant.invariantName;
-         AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+         Logger::log(Logger::Debug, "AESequenceDC", logMessage);
   	                                                                           
        end if;     
  

--- a/models/SequenceVerificationDataCentric/models/SequenceVerificationDataCentric/SVDCdomain/AESequenceDC/SVDCclasses/HappyJob/InstanceStateMachine/InstanceStateMachine.masl
+++ b/models/SequenceVerificationDataCentric/models/SequenceVerificationDataCentric/SVDCdomain/AESequenceDC/SVDCclasses/HappyJob/InstanceStateMachine/InstanceStateMachine.masl
@@ -131,7 +131,7 @@ begin
       if (prevAuditEventIds /= empty) and (prevAuditEventIds /= emptyPrevId) then
         // Log info: Event has previous event ids
         logMessage := "AESequenceDC::HappyJob.JobInProgress : Follow on event (" & auditEventId & ") for existing Job received with jobId = " & this.jobID & " with Job Name = " & theJob.jobName & ", current event type = " & theEventType.AEType & " with " & prevAuditEventIds'length'image & " previous event ids";
-	    AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);   
+	    Logger::log(Logger::Debug, "AESequenceDC", logMessage);   
 
         auditEventDataProcessed := false;
         for aPrevEventId in prevAuditEventIds loop 
@@ -183,7 +183,7 @@ begin
                 if prevEventIsValid then
                   // Previous event is valid 
                   //logMessage := "AESequenceDC::Job.JobInProgress : Previous event is valid - jobId = " & this.jobID & ", audit event sequence = " & theSequenceDef.sequenceDefinitionName & ", current event type = " & theEventType.AEType;
-	              //AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);    
+	              //Logger::log(Logger::Debug, "AESequenceDC", logMessage);    
                   // The new event is a follow on event to the previous event so we know it is part of the same sequence as the previous event
                   currentSequence := prevEvent -> R11;
                   if currentSequence /= null then
@@ -225,12 +225,12 @@ begin
                             theJob.failJob("The loop count will exceed the expected loop count which is an error for jobId = " & this.jobID & " with Job Name = " & theJob.jobName & " , current event type = " & theEventType.AEType & " , Event Id = " & newSeqEvent.AuditEventId ); 
                           end if;
                           logMessage := "AESequenceDC::HappyJob.JobInProgress : The Dynamic Control value must be a positive integer and it is not " & theUserDynamicControlDefn.dynamicControlType'image & " for " & this.jobID & " with Job Name = " & theJob.jobName & " has value = " & theUserDynamicControl.expectedDynamicControlValue'image;
-	                      AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+	                      Logger::log(Logger::Debug, "AESequenceDC", logMessage);
                         end if;  
                         
 	                  else
                         logMessage := "AESequenceDC::HappyJob.JobInProgress : This event is not carrying a Dynamic Control of type " & theUserDynamicControlDefn.dynamicControlType'image & " for " & this.jobID & " with Job Name = " & theJob.jobName;
-	                    AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+	                    Logger::log(Logger::Debug, "AESequenceDC", logMessage);
 	                  end if;  
 	                  
 	                else 
@@ -321,7 +321,7 @@ begin
                           thePrevUserDynamicControlDefn := thePrevUserDynamicControl -> R29;
                           if thePrevUserDynamicControlDefn.dynamicControlType = dynamicControlTypeEnum.BRANCHCOUNT and thePrevUserDynamicControl.expectedDynamicControlValue > 0 then
                             logMessage := "AESequenceDC::HappyJob.JobInProgress : Valid Branch Count found on instance fork in Job = " & this.jobID & " with Job Name = " & theJob.jobName & " at Event Type = " & (prevEvent -> R2).AEType;
-	                        AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);                       
+	                        Logger::log(Logger::Debug, "AESequenceDC", logMessage);                       
                           else
                             theJob.failJob("There is no Branch Count defined for this fork point in Job = " & this.jobID & " with Job Name = " & theJob.jobName & " at Event Type = " & (prevEvent -> R2).AEType);                         
                           end if;
@@ -358,7 +358,7 @@ begin
                         end if;  
 	                  else
                         logMessage := "AESequenceDC::HappyJob.JobInProgress : There is no event using a Dynamic Control of type " & theUserDynamicControlDefn.dynamicControlType'image & " for " & this.jobID & " with Job Name = " & theJob.jobName;
-	                    AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+	                    Logger::log(Logger::Debug, "AESequenceDC", logMessage);
 	                  end if;  
 
 	                  
@@ -436,7 +436,7 @@ begin
           if incompleteSequences'length = 0 then
             // Log info: Received a new sequence start event for an existing Job but other sequences are complete
 	        logMessage := "AESequenceDC::HappyJob.JobInProgress : A further new sequence has been started for - jobId = " & this.jobID & " with Job Name = " & theJob.jobName & ", with audit event = " & theEventType.AEType;
-	        AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+	        Logger::log(Logger::Debug, "AESequenceDC", logMessage);
 	        
 	        // This must be the first start event seen for a new sequence so create and link the sequence
 	        newSequence := create unique Sequence (isComplete => theAeOccInSequenceDef.isSequenceEnd, branchExtent => 1);
@@ -447,7 +447,7 @@ begin
 	      else
             // Log info: Received a new sequence start event for an existing Job - but other sequences are still in progress
 	        logMessage := "AESequenceDC::HappyJob.JobInProgress : A new sequence start event has been seen with other sequences incomplete for - jobId = " & this.jobID & " with Job Name = " & theJob.jobName & ", with audit event = " & theEventType.AEType;
-	        AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+	        Logger::log(Logger::Debug, "AESequenceDC", logMessage);
 	        
 	        // Need to check if an incomplete sequence is one of the right type for this event
 	        for incompleteSequence in incompleteSequences loop
@@ -458,7 +458,7 @@ begin
 	            incompleteSequence.branchExtent := incompleteSequence.branchExtent + 1;
                 // Log info: Received a new sequence start event that is an additional start event for an existing sequence
 	            logMessage := "AESequenceDC::HappyJob.JobInProgress : An additional sequence start event has been seen for an existing sequence for - jobId = " & this.jobID & " with Job Name = " & theJob.jobName & ", in sequence = " & incompleteSequence.AESequenceId'image & "with audit event type = " & theEventType.AEType;
-	            AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+	            Logger::log(Logger::Debug, "AESequenceDC", logMessage);
 	            
 	          end if;
 	        end loop;
@@ -594,12 +594,12 @@ begin
           if theFollowingAuditEventPairs'length /= 1 then
             validatedConstraint := false;
             logMessage := "AESequenceDC::HappyJob.AssessingJobConstraints : XOR Constraint failed for Job = " & this.jobID & " with Job Name = " & theJob.jobName & " at event " & (thePreviousAuditEvent -> R2).AEType & " with " & theFollowingAuditEventPairs'length'image & " branches following the XOR node";
-            AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);   
+            Logger::log(Logger::Debug, "AESequenceDC", logMessage);   
           end if;
         end loop;  
       else
         logMessage := "AESequenceDC::HappyJob.AssessingJobConstraints : Unsupported Constraint Type for Job = " & this.jobID & " with Job Name = " & theJob.jobName;
-        AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);    
+        Logger::log(Logger::Debug, "AESequenceDC", logMessage);    
       end if;
     end if;  
   end loop;
@@ -618,10 +618,10 @@ begin
         if (theDynamicControl.expectedDynamicControlValue > 0) and (theDynamicControl.expectedDynamicControlValue /= theDynamicControl.currentDynamicControlValue) then
           validatedDynamicControl := false;          
           logMessage := "AESequenceDC::HappyJob.AssessingJobConstraints : Loop Count check failed for Job = " & this.jobID & " with Job Name = " & theJob.jobName & " Expected Loop Count = " & theDynamicControl.expectedDynamicControlValue'image & " Current Loop Count = " & theDynamicControl.currentDynamicControlValue'image;
-          AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);    
+          Logger::log(Logger::Debug, "AESequenceDC", logMessage);    
         else
           logMessage := "AESequenceDC::HappyJob.AssessingJobConstraints : Loop Count check passed for Job = " & this.jobID & " with Job Name = " & theJob.jobName & " Expected Loop Count = " & theDynamicControl.expectedDynamicControlValue'image & " Current Loop Count = " & theDynamicControl.currentDynamicControlValue'image;
-          AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);              
+          Logger::log(Logger::Debug, "AESequenceDC", logMessage);              
         end if;
       elsif theDynamicControlDefn.dynamicControlType = dynamicControlTypeEnum.BRANCHCOUNT then
 //        if (theDynamicControl.expectedDynamicControlValue > 0) and (theDynamicControl.expectedDynamicControlValue /= theDynamicControl.currentDynamicControlValue) then
@@ -632,10 +632,10 @@ begin
           if (theDynamicControl.expectedDynamicControlValue > 0) and (theDynamicControl.currentDynamicControlValue /= theDynamicControl.expectedDynamicControlValue) then
             validatedDynamicControl := false;          
             logMessage := "AESequenceDC::HappyJob.AssessingJobConstraints : Branch Count check failed for Job = " & this.jobID & " with Job Name = " & theJob.jobName & " Expected Branch Count = " & theDynamicControl.expectedDynamicControlValue'image & " Current Branch Count = " & theBranchedEvents'length'image;
-            AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);    
+            Logger::log(Logger::Debug, "AESequenceDC", logMessage);    
           else
             logMessage := "AESequenceDC::HappyJob.AssessingJobConstraints : Branch Count check passed for Job = " & this.jobID & " with Job Name = " & theJob.jobName & " Expected Branch Count = " & theDynamicControl.expectedDynamicControlValue'image & " Current Branch Count = " & theBranchedEvents'length'image;
-            AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);              
+            Logger::log(Logger::Debug, "AESequenceDC", logMessage);              
           end if;
         else
           // This is the source branch count which isn't checked
@@ -647,10 +647,10 @@ begin
             validatedConstraint := false;    
             // TODO Remove debug log message      
             logMessage := "AESequenceDC::HappyJob.AssessingJobConstraints : Merge Count check failed for Job = " & this.jobID & " with Job Name = " & theJob.jobName & " Expected Merge Count = " & theDynamicControl.expectedDynamicControlValue'image & " Current Merge Count = " & theDynamicControl.currentDynamicControlValue'image;
-            AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);    
+            Logger::log(Logger::Debug, "AESequenceDC", logMessage);    
           else
             logMessage := "AESequenceDC::HappyJob.AssessingJobConstraints : Merge Count check passed for Job = " & this.jobID & " with Job Name = " & theJob.jobName & " Expected Merge Count = " & theDynamicControl.expectedDynamicControlValue'image & " Current Merge Count = " & theDynamicControl.currentDynamicControlValue'image;
-            AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);              
+            Logger::log(Logger::Debug, "AESequenceDC", logMessage);              
           end if;
         else
           // An event with the merge count has not been encountered so no need to check
@@ -679,7 +679,7 @@ begin
   else
     // All constraint and dynamic control checks have passed for this Job
     logMessage := "AESequenceDC::HappyJob.AssessingJobConstraints : Constraint and dynamic control checks passed for - jobId = " & this.jobID & " with Job Name = " & theJob.jobName;
-    AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+    Logger::log(Logger::Debug, "AESequenceDC", logMessage);
     generate Job.constraintCheckSuccessful() to theJob;
   end if;
   
@@ -688,7 +688,7 @@ begin
 //    generate Job.jobFailed(failureReason) to this;
 //  else
 //    logMessage := "Constraint check passed for - jobId = " & this.jobID;
-//    AsyncLogger::log(Logger::Information, "AESequenceDC", logMessage);
+//    Logger::log(Logger::Information, "AESequenceDC", logMessage);
 //    generate Job.constraintCheckSuccessful() to this;
 //  end if;
 //
@@ -726,7 +726,7 @@ begin
   
   // Log info: Audit Event Sequence Verification has been informed of Job failure
   logMessage := "AESequenceDC::HappyJob.JobFailed : Job Failed - jobId = " & this.jobID & " with Job Name = " & theJob.jobName & " due to: " & failureReason;
-  AsyncLogger::log(Logger::Error, "AESequenceDC", logMessage);
+  Logger::log(Logger::Error, "AESequenceDC", logMessage);
   eventContent := "FailureReason = " & failureReason & " : JobId = " & this.jobID & " with Job Name = " & theJob.jobName;
   Reporting~>reportEvent(Logger::Error, "svdc_job_failed", eventContent);
   for evt in theJob->R10->R11.SequencedAuditEvent loop
@@ -770,7 +770,7 @@ begin
   // Log error: new follow on event received for completed or failed Job
       // Log info: Audit Event Sequence Verification has been informed of Job completion
   logMessage := "AESequenceDC::HappyJob.JobGoneHorriblyWrong : Job gone horribly wrong - a follow on event for a completed or failed job has been received - jobId = " & this.jobID & " with Job Name = " & theJob.jobName;
-  AsyncLogger::log(Logger::Error, "AESequenceDC", logMessage);
+  Logger::log(Logger::Error, "AESequenceDC", logMessage);
   eventContent := "FailureReason = Job gone horribly wrong - a follow on event for a completed or failed job has been received" & " : JobId = " & this.jobID & " with Job Name = " & theJob.jobName;
   Reporting~>reportEvent(Logger::Error, "svdc_job_failed", eventContent);
 
@@ -794,7 +794,7 @@ begin
   theJob := this -> R45;
   // Log info: Audit Event Sequence Verification is checking for completion of a Sequence or Job
   logMessage := "AESequenceDC::HappyJob.AssessingSequenceCompletion : Checking for completion of a Sequence or Job - jobId = " & this.jobID & " with Job Name = " & theJob.jobName & " ,sequenceId = " & thePotentiallyCompletedSequence.sequenceId'image & " and branch extent = " & thePotentiallyCompletedSequence.branchExtent'image;
-  AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage); 
+  Logger::log(Logger::Debug, "AESequenceDC", logMessage); 
 
   // Test to see if this is the last 'end' event for the current sequence
   thePotentiallyCompletedSequence.branchExtent := thePotentiallyCompletedSequence.branchExtent - 1;
@@ -830,7 +830,7 @@ begin
   // TODO: Can a jobFailed event occur once this state is reached?
   theJob := this -> R45;  
   logMessage := "AESequenceDC::HappyJob.JobTimeoutReported : The Job has been reported having timed out - jobId = " & this.jobID & " with Job Name = " & theJob.jobName;
-  AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+  Logger::log(Logger::Debug, "AESequenceDC", logMessage);
   
   
   theJob.sequencingFailed := true;
@@ -867,7 +867,7 @@ begin
   jobDefinition := theJob -> R8.JobDefinition;
   // Log info: Audit Event Sequence Verification has determined that the Job is Complete
   logMessage := "AESequenceDC::HappyJob.JobSuccessful : Sequence Verification determines that the Job - jobId = " & this.jobID & " with Job Name = " & theJob.jobName & " is complete.";
-  AsyncLogger::log(Logger::Debug, "Monitored System Status", logMessage);
+  Logger::log(Logger::Debug, "Monitored System Status", logMessage);
   eventContent := "JobId = " & this.jobID & " : JobName = " & jobDefinition.jobName;
   Reporting~>reportEvent(Logger::Information, "svdc_job_success", eventContent);
   for evt in theJob->R10->R11.SequencedAuditEvent loop
@@ -900,7 +900,7 @@ begin
   JobAdmin~>deleteJob(theJobID);
 
   logMessage := "AESequenceDC::HappyJob.Deleted : Job with jobID: " & theJobID & " with Job Name = " & jobName & " has been deleted";
-  AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+  Logger::log(Logger::Debug, "AESequenceDC", logMessage);
   //
 end state;
 //! ACTIVITY END. DO NOT EDIT THIS LINE.
@@ -959,7 +959,7 @@ begin
       
       if intraJobInvariantCheckPassed then
         logMessage := "AESequenceDC::HappyJob.AssessingIntraJobInvariants : Intra-Job Invariant check passed for - jobId = " & this.jobID & " with Job Name = " & theJob.jobName;
-        AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+        Logger::log(Logger::Debug, "AESequenceDC", logMessage);
         generate Job.intraJobInvariantCheckSuccessful() to theJob;
       else
         failureReason := "Check of Intra-Job Invariants Failed";
@@ -981,7 +981,7 @@ begin
 
   //TODO Remove debug message
   logMessage := "AESequenceDC::HappyJob.AwaitingPersistenceService : Entered state Awaiting Persistence Service for - jobId = " & this.jobID & " with Job Name = " & theJob.jobName;
-  AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+  Logger::log(Logger::Debug, "AESequenceDC", logMessage);
   
   theSystemSpec := find_one SystemSpecification ();
   failureReason := " Request for invariants from the persistence store has timed out meaning the Extra Job Invariant Check has failed " & this.jobID & " with Job Name = " & theJob.jobName;
@@ -1051,11 +1051,11 @@ begin
 
       if extraJobInvariantCheckPassed then
         logMessage := "AESequenceDC::HappyJob.AssessingLocalExtraJobInvariants : Extra-Job Invariant check passed for - jobId = " & this.jobID & " with Job Name = " & theJob.jobName;
-        AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+        Logger::log(Logger::Debug, "AESequenceDC", logMessage);
         generate Job.extraJobInvariantCheckSuccessful() to theJob;
       else
         logMessage := "AESequenceDC::HappyJob.AssessingLocalExtraJobInvariants : Local Extra-Job Invariants insufficient so checking stored value for - jobId = " & this.jobID & " with Job Name = " & theJob.jobName;
-        AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+        Logger::log(Logger::Debug, "AESequenceDC", logMessage);
       end if;  
   
 end state;
@@ -1118,7 +1118,7 @@ begin
 
       if extraJobInvariantCheckPassed then
         logMessage := "AESequenceDC::HappyJob.ReassessingExtraJobInvariants : Extra-Job Invariant check passed for - jobId = " & this.jobID & " with Job Name = " & theJob.jobName;
-        AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+        Logger::log(Logger::Debug, "AESequenceDC", logMessage);
         generate Job.extraJobInvariantCheckSuccessful() to theJob;
       else
         failureReason := "Extra-Job Invariant check failed including checking stored invariants";

--- a/models/SequenceVerificationDataCentric/models/SequenceVerificationDataCentric/SVDCdomain/AESequenceDC/SVDCclasses/IntraJobInvariantDefn/IntraJobInvariantDefn.masl
+++ b/models/SequenceVerificationDataCentric/models/SequenceVerificationDataCentric/SVDCdomain/AESequenceDC/SVDCclasses/IntraJobInvariantDefn/IntraJobInvariantDefn.masl
@@ -43,7 +43,7 @@ begin
           theSequenceDefn := find_one theSequenceDefns ();
         else
           logMessage := "AESequenceDC::IntraJobInvariantDefn.createIntraJobInvariantDefn : Invalid Job Definition for this intra-job invariant definition (type 4) = " & theJobDefn.jobName;
-          AsyncLogger::log(Logger::Error, "AESequenceDC", logMessage);
+          Logger::log(Logger::Error, "AESequenceDC", logMessage);
 	      eventContent := "FailureReason = Invalid Job Definition for this intra-job invariant definition" & " : JobName = " & theJobDefn.jobName;
 	      Reporting~>reportEvent(Logger::Error, "svdc_job_definition_failed", eventContent);                
         end if;  
@@ -59,13 +59,13 @@ begin
             end if;  
           else
             logMessage := "AESequenceDC::IntraJobInvariantDefn.createIntraJobInvariantDefn : Invalid Job Definition for this intra-job invariant definition (type 3) = " & theJobDefn.jobName;
-            AsyncLogger::log(Logger::Error, "AESequenceDC", logMessage);
+            Logger::log(Logger::Error, "AESequenceDC", logMessage);
 	        eventContent := "FailureReason = Invalid Job Definition for this intra-job invariant definition" & " : JobName = " & theJobDefn.jobName;
 	        Reporting~>reportEvent(Logger::Error, "svdc_job_definition_failed", eventContent);          
           end if;  
         else
           logMessage := "AESequenceDC::IntraJobInvariantDefn.createIntraJobInvariantDefn : Invalid Job Definition for this intra-job invariant definition (type 2) = " & theJobDefn.jobName;
-          AsyncLogger::log(Logger::Error, "AESequenceDC", logMessage);
+          Logger::log(Logger::Error, "AESequenceDC", logMessage);
 	      eventContent := "FailureReason = Invalid Job Definition for this intra-job invariant definition" & " : JobName = " & theJobDefn.jobName;
 	      Reporting~>reportEvent(Logger::Error, "svdc_job_definition_failed", eventContent);            
         end if;  
@@ -74,7 +74,7 @@ begin
   else
     // Digital Twin Error dues to failed configurations
     logMessage := "AESequenceDC::IntraJobInvariantDefn.createIntraJobInvariantDefn : Invalid Job Definition for this intra-job invariant definition (type 1) = " & theJobDefn.jobName;
-    AsyncLogger::log(Logger::Error, "AESequenceDC", logMessage);
+    Logger::log(Logger::Error, "AESequenceDC", logMessage);
 	eventContent := "FailureReason = Invalid Job Definition for this intra-job invariant definition" & " : JobName = " & theJobDefn.jobName;
 	Reporting~>reportEvent(Logger::Error, "svdc_job_definition_failed", eventContent);
   end if;

--- a/models/SequenceVerificationDataCentric/models/SequenceVerificationDataCentric/SVDCdomain/AESequenceDC/SVDCclasses/Job/Job.masl
+++ b/models/SequenceVerificationDataCentric/models/SequenceVerificationDataCentric/SVDCdomain/AESequenceDC/SVDCclasses/Job/Job.masl
@@ -5,7 +5,7 @@ begin
 	
 	// This is just a progress message - the failure is reported in the state machine
 	logMessage := "AESequenceDC::Job.failJob : failed job ";
-	AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+	Logger::log(Logger::Debug, "AESequenceDC", logMessage);
 	
 		
 	generate Job.jobFailed(failureReason) to this;
@@ -221,7 +221,7 @@ logMessage : string;
 
 begin
   logMessage := "AESequenceDC::Job.migrateToUnhappyJob : Migration from Happy Job to Unhappy Job for - jobId = " & this.jobID & " with Job Name = " & this.jobName;
-  AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+  Logger::log(Logger::Debug, "AESequenceDC", logMessage);
 
   // Unlink HappyJob from Job
   theHappyJob := this -> R45.HappyJob;
@@ -242,7 +242,7 @@ begin
   // Generate firstUnhappyEvent event to UnhappyJob (this needs to leave it in a different JobInProgress state for further events which may be happy or unhappy)
 
   logMessage := "AESequenceDC::Job.migrateToUnhappyJob : Unhappy Job created for - jobId = " & this.jobID & " with Job Name = " & this.jobName ;
-  AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+  Logger::log(Logger::Debug, "AESequenceDC", logMessage);
 
   generate Job.unhappyJobCreated (eventId, prevAEIds, aeType, aeData) to this;
 end service;

--- a/models/SequenceVerificationDataCentric/models/SequenceVerificationDataCentric/SVDCdomain/AESequenceDC/SVDCclasses/JobDefinition/InstanceStateMachine/InstanceStateMachine.masl
+++ b/models/SequenceVerificationDataCentric/models/SequenceVerificationDataCentric/SVDCdomain/AESequenceDC/SVDCclasses/JobDefinition/InstanceStateMachine/InstanceStateMachine.masl
@@ -15,7 +15,7 @@ begin
   this.isDeprecated := true;
   // Log info: Report that the JobDefinition has been deprecated.
   logMessage := "AESequenceDC::JobDefinition.Deprecated : JobDefinition has been deprecated - jobName = " & this.jobName;
-  AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage); 
+  Logger::log(Logger::Debug, "AESequenceDC", logMessage); 
   
   // Check to see if there are any Jobs in progress that are dependent upon this JobDefinition.
   if (this -> R8)'length = 0 then
@@ -51,7 +51,7 @@ begin
   
   // Log info: Report that the deprecated JobDefinition has been deleted.
   logMessage := "AESequenceDC::JobDefinition.Deleted : Deprecated JobDefinition has been deleted - jobName = " & theJobName;
-  AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage); 
+  Logger::log(Logger::Debug, "AESequenceDC", logMessage); 
 end state;
 //! ACTIVITY END. DO NOT EDIT THIS LINE.
 

--- a/models/SequenceVerificationDataCentric/models/SequenceVerificationDataCentric/SVDCdomain/AESequenceDC/SVDCclasses/JobDefinition/JobDefinition.masl
+++ b/models/SequenceVerificationDataCentric/models/SequenceVerificationDataCentric/SVDCdomain/AESequenceDC/SVDCclasses/JobDefinition/JobDefinition.masl
@@ -158,7 +158,7 @@ begin
     delete this;
     
     logMessage := "AESequenceDC::JobDefinition.deleteJobDefinition : Job Definition " & jobName & " has been deleted";
-	AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+	Logger::log(Logger::Debug, "AESequenceDC", logMessage);
     
 end service;
 //! ACTIVITY END. DO NOT EDIT THIS LINE.

--- a/models/SequenceVerificationDataCentric/models/SequenceVerificationDataCentric/SVDCdomain/AESequenceDC/SVDCclasses/PersistedInvariant/InstanceStateMachine/InstanceStateMachine.masl
+++ b/models/SequenceVerificationDataCentric/models/SequenceVerificationDataCentric/SVDCdomain/AESequenceDC/SVDCclasses/PersistedInvariant/InstanceStateMachine/InstanceStateMachine.masl
@@ -13,7 +13,7 @@ logMessage : string;
 begin
   // Report the current state of PersistedInvariant
   logMessage := "AESequenceDC::PersistedInvariant.InForce : PersistedInvariant: " & this.invariantId'image & " is InForce";
-  AsyncLogger::log(Logger::Information, "AESequenceDC", logMessage); 
+  Logger::log(Logger::Information, "AESequenceDC", logMessage); 
   
   this.inForce := true;
   schedule this.invariantTimer generate PersistedInvariant.invariantExpires() to this at this.validUntil;
@@ -29,7 +29,7 @@ logMessage : string;
 begin
   // Report the current state of PersistedInvariant
   logMessage := "AESequenceDC::PersistedInvariant.Deprecated : PersistedInvariant: " & this.invariantId'image & " (Name: " & this.invariantName & ", Value: " & this.invariantValue & ") has been Deprecated";
-  AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage); 
+  Logger::log(Logger::Debug, "AESequenceDC", logMessage); 
   
   theSystemSpec := find_only SystemSpecification();
   this.inForce := false;
@@ -45,7 +45,7 @@ logMessage : string;
 begin
   // Report the current state of PersistedInvariant
   logMessage := "AESequenceDC::PersistedInvariant.Deleted : PersistedInvariant: " & this.invariantId'image & " (Name: " & this.invariantName & ", Value: " & this.invariantValue & ") is about to be deleted";
-  AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage); 
+  Logger::log(Logger::Debug, "AESequenceDC", logMessage); 
   
   // Unlink the specification class
   if (this -> R24) /= null then

--- a/models/SequenceVerificationDataCentric/models/SequenceVerificationDataCentric/SVDCdomain/AESequenceDC/SVDCclasses/PersistedInvariant/PersistedInvariant.masl
+++ b/models/SequenceVerificationDataCentric/models/SequenceVerificationDataCentric/SVDCdomain/AESequenceDC/SVDCclasses/PersistedInvariant/PersistedInvariant.masl
@@ -27,7 +27,7 @@ begin
     
     // Log info: Audit event data provided with this audit event has been captured
 	logMessage := "The persisted invariant " & newExtraJobInvariant.invariantName & " with value = " & newExtraJobInvariant.invariantValue & " has has been created";
-    AsyncLogger::log(Logger::Information, "AESequenceDC", logMessage); 
+    Logger::log(Logger::Information, "AESequenceDC", logMessage); 
     
     generate PersistedInvariant.invariantComesIntoForce() to newExtraJobInvariant;
     sourceAEOccurrenceDefn := extraJobInvDefn -> R20;
@@ -74,7 +74,7 @@ begin
         
     // ... and finally deleted the specified instance of PersistedInvariant and log this.    
     logMessage := "AESequenceDC::PersistedInvariant.deletePersistedInvariant : PersistentInvariant: " & this.invariantId'image & " deleted ";
-    AsyncLogger::log(Logger::Information, "AESequenceDC", logMessage);
+    Logger::log(Logger::Information, "AESequenceDC", logMessage);
     delete this;
 end service;
 //! ACTIVITY END. DO NOT EDIT THIS LINE.

--- a/models/SequenceVerificationDataCentric/models/SequenceVerificationDataCentric/SVDCdomain/AESequenceDC/SVDCclasses/SequencedAuditEvent/SequencedAuditEvent.masl
+++ b/models/SequenceVerificationDataCentric/models/SequenceVerificationDataCentric/SVDCdomain/AESequenceDC/SVDCclasses/SequencedAuditEvent/SequencedAuditEvent.masl
@@ -74,7 +74,7 @@ begin
         // The first event for this new Job is a valid event type for starting the sequence
         // Log info: new Job and event sequence started
         logMessage := "AESequenceDC::SequencedAuditEvent.AddEventForNewJob : New Job started - jobId = " & newJob.jobID & " with Job Name = " & newJob.jobName & ", Initial audit event: " & eventId & " of type " & newEventType.AEType;
-	    AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+	    Logger::log(Logger::Debug, "AESequenceDC", logMessage);
 		eventContent := "JobId = " & newJob.jobID & " : EventId = " & eventId & " : EventType = " & newEventType.AEType;
 		Reporting~>reportEvent(Logger::Information, "svdc_new_job_started", eventContent);
         
@@ -106,7 +106,7 @@ begin
   else
       // Log error: The audit event id received has been seen before
 	  logMessage := "AESequenceDC::SequencedAuditEvent.AddEventForNewJob : The audit event has been seen before for jobId = " & jobId & " with Job Name = " & jobName & ", Initial audit event = " & aeType;
-	  AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+	  Logger::log(Logger::Debug, "AESequenceDC", logMessage);
       eventContent := "JobId = " & jobId & " with Job Name = " & jobName & " : FailureReason = The audit event has been seen before"  & " : EventId = " & eventId & " : EventType = " & aeType;
 	  Reporting~>reportEvent(Logger::Error, "svdc_job_failed", eventContent);  
 
@@ -241,14 +241,14 @@ totalDynamicControls : set of instance of DynamicControl;
                   link newIntraJobInvariant R26 theIntraJobInvariantDefn;
                   // Log info: Audit event data provided with this audit event has been captured
 	              logMessage := "AESequenceDC::SequencedAuditEvent.ProcessAuditEventData " & aeDataElement.aedName & " provided for jobId = " & theJob.jobID & " with Job Name = " & theJob.jobName & " has been added for this type of audit event = " & theEventType.AEType & " with value = " & newIntraJobInvariant.invariantValue;
-	              AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage); 
+	              Logger::log(Logger::Debug, "AESequenceDC", logMessage); 
 	            else
                   theJob.failJob("Empty Invariant Value provided for this Job = " & theJob.jobID & " and Event Type = " & theEventType.AEType);        
 	            end if;                 
               else
                 // Log warning: The audit event data type provided with this audit event is of a disallowed type for this type of audit event
 	            logMessage := "AESequenceDC::SequencedAuditEvent.ProcessAuditEventData : The audit event data type " & aeDataElement.aedName & " provided for jobId = " & theJob.jobID & " with Job Name = " & theJob.jobName & " is disallowed for this type of audit event = " & theEventType.AEType;
-	            AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);                
+	            Logger::log(Logger::Debug, "AESequenceDC", logMessage);                
                 theJob.failJob("Invalid audit event data type for - Job Id = " & theJob.jobID & " and Event Type = " & theEventType.AEType);
               end if;
             else
@@ -289,7 +289,7 @@ totalDynamicControls : set of instance of DynamicControl;
                   link theUserExtraJobInvariant R28 theUserExtraJobInvariantDefn;
                   // Log info: Audit event data provided with this audit event has been captured
 	              logMessage := "AESequenceDC::SequencedAuditEvent.ProcessAuditEventData : The audit event data type " & aeDataElement.aedName & " provided for jobId = " & theJob.jobID & " with Job Name = " & theJob.jobName & " has been added for this type of audit event = " & theEventType.AEType;
-	              AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage); 
+	              Logger::log(Logger::Debug, "AESequenceDC", logMessage); 
 	            else
                   theJob.failJob("Empty Invariant Value provided for this Job = " & theJob.jobID & " and Event Type = " & theEventType.AEType);        
 	            end if; 
@@ -440,7 +440,7 @@ logMessage : string;
 begin
   // TODO: Remove the following log message - just for debug
   logMessage := "Checking received event data against definition";
-  AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+  Logger::log(Logger::Debug, "AESequenceDC", logMessage);
 	
   // Initialise return parameters
   checkHasPassed := true;

--- a/models/SequenceVerificationDataCentric/models/SequenceVerificationDataCentric/SVDCdomain/AESequenceDC/SVDCclasses/UnhappyJob/InstanceStateMachine/InstanceStateMachine.masl
+++ b/models/SequenceVerificationDataCentric/models/SequenceVerificationDataCentric/SVDCdomain/AESequenceDC/SVDCclasses/UnhappyJob/InstanceStateMachine/InstanceStateMachine.masl
@@ -63,7 +63,7 @@ begin
     // and to the sequenced event definition
     link newSeqEvent R2 theEventType;
     logMessage := "AESequenceDC::UnhappyJob.JobInProgress : Happy event seen in Unhappy Job (" & auditEventId & ") for existing Job received with jobId = " & this.jobID & " with Job Name = " & theJob.jobName & ", current event type = " & auditEventType & " with " & prevAuditEventIds'length'image & " previous event ids";
-	AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);   
+	Logger::log(Logger::Debug, "AESequenceDC", logMessage);   
     
   end if;
 
@@ -80,7 +80,7 @@ begin
     link newUnseqEvent R41 theUnseqEventType;
 
     logMessage := "AESequenceDC::UnhappyJob.JobInProgress : Unhappy event seen in Unhappy Job (" & auditEventId & ") for existing Job received with jobId = " & this.jobID & " with Job Name = " & theJob.jobName & ", current event type = " & auditEventType & " with " & prevAuditEventIds'length'image & " previous event ids";
-	AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);   
+	Logger::log(Logger::Debug, "AESequenceDC", logMessage);   
     
    // TODO Add possible section to deal with an Unhappy Event being marked as a Job End event
    if theUnseqEventType.isEndEvent then
@@ -94,7 +94,7 @@ begin
     if (prevAuditEventIds /= empty) and (prevAuditEventIds /= emptyPrevId) then
       // Log info: Event has previous event ids
       logMessage := "AESequenceDC::UnhappyJob.JobInProgress : Follow on event in Unhappy Job (" & auditEventId & ") for existing Job received with jobId = " & this.jobID & " with Job Name = " & theJob.jobName & ", current event type = " & auditEventType & " with " & prevAuditEventIds'length'image & " previous event ids";
-	  AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);   
+	  Logger::log(Logger::Debug, "AESequenceDC", logMessage);   
 
       //auditEventDataProcessed := false;
       for aPrevEventId in prevAuditEventIds loop 
@@ -198,7 +198,7 @@ unhappyJobFailureReason := failureReason;
   
   // Log info: Audit Event Sequence Verification has been informed of Job failure
   logMessage := "AESequenceDC::Job.JobFailed : Alarm Condition in - jobId = " & this.jobID & " with Job Name = " & theJob.jobName & " due to: " & unhappyJobFailureReason;
-  AsyncLogger::log(Logger::Error, "AESequenceDC", logMessage);
+  Logger::log(Logger::Error, "AESequenceDC", logMessage);
   eventContent := "Alarm Condition = " & unhappyJobFailureReason & " : JobId = " & this.jobID & " with Job Name = " & theJob.jobName;
   Reporting~>reportEvent(Logger::Error, "svdc_job_alarm", eventContent);
   for evt in theJob-> R44.SequencedAuditEvent loop
@@ -237,7 +237,7 @@ begin
   // Log error: new follow on event received for completed or failed Job
       // Log info: Audit Event Sequence Verification has been informed of Job completion
   logMessage := "AESequenceDC::UnhappyJob.JobGoneHorriblyWrong : Job gone horribly wrong - a follow on event for a completed or failed job has been received - jobId = " & this.jobID & " with Job Name = " & theJob.jobName;
-  AsyncLogger::log(Logger::Error, "AESequenceDC", logMessage);
+  Logger::log(Logger::Error, "AESequenceDC", logMessage);
   eventContent := "FailureReason = Job gone horribly wrong - a follow on event for a completed or failed job has been received" & " : JobId = " & this.jobID & " with Job Name = " & theJob.jobName;
   Reporting~>reportEvent(Logger::Error, "svdc_job_failed", eventContent);
 
@@ -256,7 +256,7 @@ begin
   // TODO: Can a jobFailed event occur once this state is reached?
   theJob := this -> R45;  
   logMessage := "AESequenceDC::UnhappyJob.JobTimeoutReported : The Unhappy Job has been reported having timed out - jobId = " & this.jobID & " with Job Name = " & theJob.jobName;
-  AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+  Logger::log(Logger::Debug, "AESequenceDC", logMessage);
   
   // As this is a normal way of detecting the end of an Unhappy Job this will not be regarded as a failure condition
   // However, this is left as a separate state in case there is other behaviour we need to add.
@@ -284,7 +284,7 @@ begin
   jobDefinition := theJob -> R8.JobDefinition;
   // Log info: Audit Event Sequence Verification has determined that the Job is Complete
   logMessage := "AESequenceDC::UnhappyJob.JobSuccessful : Sequence Verification determines that the Unhappy Job - jobId = " & this.jobID & " with Job Name = " & theJob.jobName & " has ended without an alarm condition being raised.";
-  AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+  Logger::log(Logger::Debug, "AESequenceDC", logMessage);
   eventContent := "JobId = " & this.jobID & " : JobName = " & jobDefinition.jobName;
   Reporting~>reportEvent(Logger::Information, "svdc_job_success", eventContent);
   for evt in theJob-> R44.SequencedAuditEvent loop
@@ -321,7 +321,7 @@ begin
   JobAdmin~>deleteJob(theJobID);
 
   logMessage := "AESequenceDC::Job.Deleted : Job with jobID: " & theJobID & " with Job Name = " & jobName & " has been deleted";
-  AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+  Logger::log(Logger::Debug, "AESequenceDC", logMessage);
   //
 end state;
 //! ACTIVITY END. DO NOT EDIT THIS LINE.
@@ -376,7 +376,7 @@ begin
       
       if intraJobInvariantCheckPassed then
         logMessage := "AESequenceDC::UnhappyJob.AssessingIntraJobInvariants : Intra-Job Invariant check passed for Unhappy Job - jobId = " & this.jobID & " with Job Name = " & theJob.jobName;
-        AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+        Logger::log(Logger::Debug, "AESequenceDC", logMessage);
         generate Job.intraJobInvariantCheckSuccessful() to theJob;
       else
         failureReason := "Check of Intra-Job Invariants in Unhappy Job Failed";
@@ -398,7 +398,7 @@ begin
 
   //TODO Remove debug message
   logMessage := "AESequenceDC::UnhappyJob.AwaitingPersistenceService : Entered state Awaiting Persistence Service for Unhappy job - jobId = " & this.jobID & " with Job Name = " & theJob.jobName;
-  AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+  Logger::log(Logger::Debug, "AESequenceDC", logMessage);
   
   theSystemSpec := find_one SystemSpecification ();
   failureReason := " Request for invariants from the persistence store has timed out meaning the Extra Job Invariant Check has failed " & this.jobID;
@@ -468,11 +468,11 @@ begin
 
       if extraJobInvariantCheckPassed then
         logMessage := "AESequenceDC::UnhappyJob.AssessingLocalExtraJobInvariants : Extra-Job Invariant check passed for Unhappy Job - jobId = " & this.jobID & " with Job Name = " & theJob.jobName;
-        AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+        Logger::log(Logger::Debug, "AESequenceDC", logMessage);
         generate Job.extraJobInvariantCheckSuccessful() to theJob;
       else
         logMessage := "AESequenceDC::UnhappyJob.AssessingLocalExtraJobInvariants : Local Extra-Job Invariants insufficient so checking stored value for Unhappy Job - jobId = " & this.jobID & " with Job Name = " & theJob.jobName;
-        AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+        Logger::log(Logger::Debug, "AESequenceDC", logMessage);
       end if;  
   
 end state;
@@ -535,7 +535,7 @@ begin
 
       if extraJobInvariantCheckPassed then
         logMessage := "AESequenceDC::UnhappyJob.ReassessingExtraJobInvariants : Extra-Job Invariant check passed for Unhappy Job - jobId = " & this.jobID & " with Job Name = " & theJob.jobName;
-        AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+        Logger::log(Logger::Debug, "AESequenceDC", logMessage);
         generate Job.extraJobInvariantCheckSuccessful() to theJob;
       else
         failureReason := "Extra-Job Invariant check failed including checking stored invariants for Unhappy Job";
@@ -581,7 +581,7 @@ begin
   theJobsCriticalEvents := theJobsEvents intersection theCriticalEvents;
 
   logMessage := "AESequenceDC::UnhappyJob.AssessingUnhappyJobCompletion for Job with jobId = " & theJob.jobID;
-  AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);   
+  Logger::log(Logger::Debug, "AESequenceDC", logMessage);   
   
   for eachCriticalEvent in theJobsCriticalEvents loop
     theParentEvents := eachCriticalEvent -> R46 -> R47.has_previous.AuditEvent;
@@ -651,18 +651,18 @@ begin
       end loop;  
     else
       logMessage := "AESequenceDC::UnhappyJob.AssessingUnhappyJobCompletion - No child events found for unhappy event in Job with jobId = " & theJob.jobID & " and job type " & theJob.jobName;
-      AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+      Logger::log(Logger::Debug, "AESequenceDC", logMessage);
     end if;
     
     theJobsCriticalAuditEvents := theJobsCriticalEvents -> R46;  
     inScopeCriticalEvents := (theJobsCriticalAuditEvents intersection theDecendantEvents);    
     
     logMessage := "AESequenceDC::UnhappyJob.AssessingUnhappyJobCompletion - The following critical events are in the scope of the unhappy event for Job with jobId = " & theJob.jobID & " and job type " & theJob.jobName;
-    AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+    Logger::log(Logger::Debug, "AESequenceDC", logMessage);
     for inScopeCriticalEvent in inScopeCriticalEvents loop
       inScopeCriticalEventDefinition := inScopeCriticalEvent -> R46.SequencedAuditEvent -> R2;
       logMessage := "  In scope Critical Event  = " & inScopeCriticalEvent.AEId & " of type " & inScopeCriticalEventDefinition.AEType;
-      AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);      
+      Logger::log(Logger::Debug, "AESequenceDC", logMessage);      
     end loop;   
   end if;     
   
@@ -681,7 +681,7 @@ begin
   
   if isSuccess then
     logMessage := "AESequenceDC::UnhappyJob.AssessingUnhappyJobCompletion - The Unhappy Job has completed without an alarm condition for jobId = " & theJob.jobID & " and job type " & theJob.jobName;
-    AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+    Logger::log(Logger::Debug, "AESequenceDC", logMessage);
     generate UnhappyJob.unhappyJobBehavedAsExpected () to this;
   else
     // TODO At the moment we are treating this as a job failed condition. We may want to raise this to an alarm condition

--- a/models/SequenceVerificationDataCentric/models/SequenceVerificationDataCentric/SVDCdomain/AESequenceDC/SVDCclasses/UnsequencedAuditEvent/UnsequencedAuditEvent.masl
+++ b/models/SequenceVerificationDataCentric/models/SequenceVerificationDataCentric/SVDCdomain/AESequenceDC/SVDCclasses/UnsequencedAuditEvent/UnsequencedAuditEvent.masl
@@ -25,7 +25,7 @@ begin
     // Note: SequencingFailed is marked true for an UnhappyJob
 
     logMessage := "AESequenceDC::UnsequencedAuditEvent.AddEventForNewUnhappyJob : First event for Job is an unhappy event - job id = " & jobId & " with Job Name = " & jobName & ", Initial audit event: " & eventId & " of type " & aeType;
-	AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+	Logger::log(Logger::Debug, "AESequenceDC", logMessage);
     
     newJob := create Job (jobID => jobId, sequencingFailed => true, jobCompleted => false );
     newUnhappyJob := create UnhappyJob (jobID => jobId, Current_State => Created );
@@ -44,13 +44,13 @@ begin
       else
         newJob.failJob("An unrecognised job definition has been received - Job Id = " & newJob.jobID & " with Job Name = " & newJob.jobName & " Event Type = " & aeType);      
         logMessage := "AESequenceDC::UnsequencedAuditEvent.AddEventForNewUnhappyJob : No Job Definition found for - job Name = " & jobName & ", Initial audit event: " & eventId & " of type " & aeType;
-	    AsyncLogger::log(Logger::Error, "AESequenceDC", logMessage);
+	    Logger::log(Logger::Error, "AESequenceDC", logMessage);
       end if;  
     
   else
       // Log error: The audit event id received has been seen before
 	  logMessage := "AESequenceDC::UnsequencedAuditEvent.AddEventForNewJob : The audit event has been seen before for jobId = " & jobId & " with Job Name = " & jobName & ", Initial audit event = " & aeType;
-	  AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+	  Logger::log(Logger::Debug, "AESequenceDC", logMessage);
       eventContent := "JobId = " & jobId & " with Job Name = " & jobName & " : FailureReason = The audit event has been seen before"  & " : EventId = " & eventId & " : EventType = " & aeType;
 	  Reporting~>reportEvent(Logger::Error, "svdc_job_failed", eventContent);  
 

--- a/models/SequenceVerificationDataCentric/models/SequenceVerificationDataCentric/SVDCdomain/AESequenceDC/functions/functions.masl
+++ b/models/SequenceVerificationDataCentric/models/SequenceVerificationDataCentric/SVDCdomain/AESequenceDC/functions/functions.masl
@@ -36,7 +36,7 @@ begin
     if (knownJobDefinition.isSuspended = true) or (knownJobDefinition.isDeprecated = true)then
       // Log info: The accepted event is for a new Job that has a non-active JobDefinition 
       logMessage := "AESequenceDC::acceptorderedEvent : The event - AuditEventId = " & id & "cannot be accepted because it relates to a new Job whose JobDefinition is either Suspended or Deprecated";
-      AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);        
+      Logger::log(Logger::Debug, "AESequenceDC", logMessage);        
       eventContent := "JobId = " & jobId  & " with Job Name = " & jobName & " : EventId = " & id & " : EventType = " & ae_type & " : FailureReason = The event cannot be accepted because it relates to a new Job whose JobDefinition is either Suspended or Deprecated";
       Reporting~>reportEvent(Logger::Error, "svdc_invalid_event", eventContent);
     else    
@@ -70,7 +70,7 @@ begin
         else
           // Log info: Report that the specified audit event type (ae_type) does not exist for this job definition.
           logMessage := "AESequenceDC::acceptorderedEvent : Accepted event is of an unknown type for this job definition - AEType = " & ae_type & " for Job Name = " & jobName;
-          AsyncLogger::log(Logger::Error, "AESequenceDC", logMessage); 
+          Logger::log(Logger::Error, "AESequenceDC", logMessage); 
           eventContent := "JobId = " & jobId  & " with Job Name = " & jobName & " : EventId = " & id & " : EventType = " & ae_type & " : FailureReason = Accepted event is of an unknown Event type";
           Reporting~>reportEvent(Logger::Error, "svdc_invalid_event", eventContent);
         end if;
@@ -79,7 +79,7 @@ begin
   else
     // Log info: Report that the specified job definition as indicated by jobName does not exist.
     logMessage := "AESequenceDC::acceptorderedEvent : The specified Job Type is unknown = " & jobName;
-    AsyncLogger::log(Logger::Error, "AESequenceDC", logMessage); 
+    Logger::log(Logger::Error, "AESequenceDC", logMessage); 
     eventContent := "JobId = " & jobId  & " with Job Name = " & jobName & " : EventId = " & id & " : EventType = " & ae_type & " : FailureReason = Accepted event is of an unknown Job type";
     Reporting~>reportEvent(Logger::Error, "svdc_invalid_event", eventContent);
     
@@ -155,13 +155,13 @@ eventContent : string;
 //
 begin
   logMessage := "AESequenceDC::eventDefinition : New Event Definition, Job Definition = " & jobName & "Sequence Name = " & sequenceName & " event type = " & eventType & " Start = " & isSequenceStart'image & " End = " & isSequenceEnd'image & " Break = " & isBreak'image & " Happy = " & isHappy'image & " Critical = " & isCritical'image ;
-  AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+  Logger::log(Logger::Debug, "AESequenceDC", logMessage);
   theJobDefn := find_one JobDefinition (jobName = jobName);
   if theJobDefn = null then
     // Event Definition for new Job so create the Job Definition
     theJobDefn := create unique JobDefinition (jobName => jobName, isDeprecated => false, isSuspended => false, Current_State => Active);
     logMessage := "AESequenceDC::eventDefinition : New Job Definition added, Job Definition = " & theJobDefn.jobName;
-    AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+    Logger::log(Logger::Debug, "AESequenceDC", logMessage);
   end if; 
 
   if isHappy then
@@ -173,7 +173,7 @@ begin
       theSequenceDefn := create unique AESequenceDefinition (sequenceDefinitionName => sequenceName);
       link theSequenceDefn R7 theJobDefn;
       logMessage := "AESequenceDC::eventDefinition : New Sequence Definition added, Job Definition = " & theJobDefn.jobName & ", Sequence Definition = " & theSequenceDefn.sequenceDefinitionName;
-      AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+      Logger::log(Logger::Debug, "AESequenceDC", logMessage);
     end if;
    
     theEventDefn := find_one SequencedAuditEventDefinition (AEType = eventType);
@@ -202,7 +202,7 @@ begin
                                                                     isBreak => isBreak);
       link theEventOccInSeqDef R12 theEventInSeqDef;
       logMessage := "AESequenceDC::eventDefinition : New Happy Event Definition added, Job Definition = " & theJobDefn.jobName & ", Sequence Definition = " & theSequenceDefn.sequenceDefinitionName & ", Event type = " & theEventDefn.AEType;
-      AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+      Logger::log(Logger::Debug, "AESequenceDC", logMessage);
     elsif theExistingEventDefn /= null then
       // The event definition has been seen before which could indicate the repetition of an event type within a sequence or the repetition of an event type in a different job definition
       theEventDefnsInSequence := theSequenceDefn -> R1.SequencedAuditEventDefinition;
@@ -224,7 +224,7 @@ begin
                                                                       );
           link theEventInSeqDef R12 theEventOccInSeqDef;
           logMessage := "AESequenceDC::eventDefinition : Additional Event Occurrence Definition added, Job Definition = " & theJobDefn.jobName & ", Sequence Definition = " & theSequenceDefn.sequenceDefinitionName & ", Event type = " & theEventDefn.AEType;
-          AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+          Logger::log(Logger::Debug, "AESequenceDC", logMessage);
         else
           // It is a placeholder so now we've seen it for real we can clear the isPlaceholder flag and set the other flags according to input data
           thePlaceholderEventOccInSeqDef.isPlaceholder := false;
@@ -236,7 +236,7 @@ begin
       else  
         // For now assume this is not allowed. TODO Check to see if the same event type can legitimately occur in different Job Types and Sequences
         logMessage := "AESequenceDC::eventDefinition : The event type provided in the initialisation data has been seen elsewhere , Job Definition = " & theJobDefn.jobName & ", Sequence Definition = " & theSequenceDefn.sequenceDefinitionName & ", Event type = " & theEventDefn.AEType;
-        AsyncLogger::log(Logger::Error, "AESequenceDC", logMessage);
+        Logger::log(Logger::Error, "AESequenceDC", logMessage);
 	    eventContent := "FailureReason = The event type provided in the initialisation data has been seen elsewhere" & " : JobName = " & theJobDefn.jobName  & " : SequenceDefinition = " & theSequenceDefn.sequenceDefinitionName & " : EventType = " & theEventDefn.AEType;
         Reporting~>reportEvent(Logger::Error, "svdc_invalid_event_definition", eventContent);
       end if;
@@ -261,7 +261,7 @@ begin
                                                                     isBreak => isBreak);
       link theEventOccInSeqDef R12 theEventInSeqDef;
       logMessage := "AESequenceDC::eventDefinition : Event Definition seen in another Job added to Job Definition = " & theJobDefn.jobName & ", Sequence Definition = " & theSequenceDefn.sequenceDefinitionName & ", Event type = " & theEventDefn.AEType;
-      AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+      Logger::log(Logger::Debug, "AESequenceDC", logMessage);
       
     end if;
   
@@ -292,7 +292,7 @@ begin
                 theConstraintDefn := create ConstraintDefinition (constraintDefnId => previousEventType.constraintDefId, jobName => theJobDefn.jobName, constraintType => XOR );
               else
                 logMessage := "AESequenceDC::eventDefinition : Invalid Constraint Value provided : " & previousEventType.constraintValue & "in Job Name = " & jobName;
-	            AsyncLogger::log(Logger::Error, "AESequenceDC", logMessage);
+	            Logger::log(Logger::Error, "AESequenceDC", logMessage);
 	            eventContent := "FailureReason = Invalid Constraint Value provided" & " : JobName = " & jobName  & " : ConstraintValue = " & previousEventType.constraintValue;
 	            Reporting~>reportEvent(Logger::Error, "svdc_invalid_event", eventContent);
               end if;
@@ -304,7 +304,7 @@ begin
               // No constraint specified which is valid
             else
               logMessage := "AESequenceDC::eventDefinition : Invalid Constraint Definition provided : " & previousEventType.constraintDefId & "in Job Name = " & jobName;
-	          AsyncLogger::log(Logger::Error, "AESequenceDC", logMessage);            
+	          Logger::log(Logger::Error, "AESequenceDC", logMessage);            
 	          eventContent := "FailureReason = Invalid Constraint Definition provided" & " : JobName = " & jobName  & " : ConstraintDefId = " & previousEventType.constraintDefId;
 	          Reporting~>reportEvent(Logger::Error, "svdc_invalid_event", eventContent);
             end if;
@@ -312,7 +312,7 @@ begin
             // We have a reference to a forward event which is possible in the case of cyclic sequences so create a placeholder event
             // In this case the event definition has been seen before but not this referenced occurrence number
             logMessage := "AESequenceDC::eventDefinition :  There is a forward reference to an event so create a Placeholder for the new event occurrence: " & thePrevEventDefn.AEType & " in Job Name = " & jobName;
-	        AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);            
+	        Logger::log(Logger::Debug, "AESequenceDC", logMessage);            
           
             thePlaceholderEventDefn := thePrevEventDefn; 
             thePlaceholderEventInSeqDef := thePlaceholderEventDefn with theSequenceDefn -> R1;
@@ -338,7 +338,7 @@ begin
           // We have a reference to a forward event which is possible in the case of cyclic sequences so create a placeholder event
           // In this case the event definition has not been seen at all
           logMessage := "AESequenceDC::eventDefinition :  There is a forward reference to an event so create a Placeholder for event type: " & previousEventType.eventTypeName & " in Job Name = " & jobName;
-	      AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);            
+	      Logger::log(Logger::Debug, "AESequenceDC", logMessage);            
           thePlaceholderEventDefn := find_one SequencedAuditEventDefinition (AEType = previousEventType.eventTypeName);
           if thePlaceholderEventDefn = null then
             thePlaceholderEventDefn := create unique SequencedAuditEventDefinition (AEType => previousEventType.eventTypeName); 
@@ -379,11 +379,11 @@ begin
         
           // The previous event definition provided is unknown
           //logMessage := "AESequenceDC::eventDefinition : Previous event types provided in the initialisation data are unknown, Job Definition = " & theJobDefn.jobName & ", Sequence Definition = " & theSequenceDefn.sequenceDefinitionName & ", Event type = " & theEventDefn.AEType& ", Previous event type = " & previousEventType.eventTypeName;
-	      //AsyncLogger::log(Logger::Error, "AESequenceDC", logMessage);                  
+	      //Logger::log(Logger::Error, "AESequenceDC", logMessage);                  
         end if;
 
 //      logMessage := "AESequenceDC::eventDefinition : Multiple previous event types provided in the initialisation data. Not currently supported, Job Definition = " & theJobDefn.jobName & ", Sequence Definition = " & theSequenceDefn.sequenceDefinitionName & ", Event type = " & theEventDefn.AEType;
-//	  AsyncLogger::log(Logger::Error, "AESequenceDC", logMessage);            
+//	  Logger::log(Logger::Error, "AESequenceDC", logMessage);            
         
 //    end if;
     end loop;
@@ -397,20 +397,20 @@ begin
                                                                          jobName => theJobDefn.jobName); 
         link theUnseqEventDefn R39 theJobDefn using theUnseqEventDefnInJobDefn ;
         logMessage := "AESequenceDC::eventDefinition : New Unhappy Event Definition added, Job Definition = " & theJobDefn.jobName & ", Unhappy Event type = " & theUnseqEventDefn.UnsequencedAEType;
-        AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+        Logger::log(Logger::Debug, "AESequenceDC", logMessage);
   
     else
         theUnseqEventDefnInJobDefn := create UnsequencedAEDefnInJobDefn (UnsequencedAEDefnId => theUnseqEventDefn.UnsequencedAEDefnId,
                                                                          jobName => theJobDefn.jobName); 
         link theUnseqEventDefn R39 theJobDefn using theUnseqEventDefnInJobDefn ;
         logMessage := "AESequenceDC::eventDefinition : Existing Unhappy Event Definition found and added to this Job Definition = " & theJobDefn.jobName & ", Unhappy Event type = " & theUnseqEventDefn.UnsequencedAEType;
-        AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+        Logger::log(Logger::Debug, "AESequenceDC", logMessage);
     end if;
     
     // The following checks that an unhappy event is not marked as a critical event as that combination is not allowed
     if isCritical then
       logMessage := "AESequenceDC::eventDefinition : The event type provided in the initialisation data is marked as Critical and an Unhappy Event - this combination is not allowed, Job Definition = " & theJobDefn.jobName & ", Event type = " & theEventDefn.AEType;
-      AsyncLogger::log(Logger::Error, "AESequenceDC", logMessage);
+      Logger::log(Logger::Error, "AESequenceDC", logMessage);
 	  eventContent := "FailureReason = The event type provided in the initialisation data is marked as Critical and an Unhappy Event - this combination is not allowed " & " : JobName = " & theJobDefn.jobName  & " : EventType = " & theEventDefn.AEType;
       Reporting~>reportEvent(Logger::Error, "svdc_invalid_event_definition", eventContent);
     end if;
@@ -433,7 +433,7 @@ begin
   else
 
     logMessage := "AESequenceDC::deleteJob : jobId provided is unknown " & jobId;
-	AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+	Logger::log(Logger::Debug, "AESequenceDC", logMessage);
       
   end if;
   //
@@ -457,7 +457,7 @@ begin
   else
   
     logMessage := "AESequenceDC::deprecatedJobDefinition : Job Definition specified for deprecation is unknown - jobName " & jobName;
-	AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+	Logger::log(Logger::Debug, "AESequenceDC", logMessage);
   
   end if;  
 end service;
@@ -508,7 +508,7 @@ begin
   else
   
     logMessage := "AESequenceDC::suspendJobDefinition : The JobDefinition specified for suspension is unknown - jobName " & jobName;
-	AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+	Logger::log(Logger::Debug, "AESequenceDC", logMessage);
   
   end if;
 end service;
@@ -527,7 +527,7 @@ begin
     // Check whether the respective JobDefinition is in the 'Suspended' state.
     if theJobDefn.isSuspended /= true then
       logMessage := "AESequenceDC::reactivateJobDefinition : Reactivation attempt of JobDefinition - jobName " & jobName & "failed because it was not in the SUSPENDED state";
-	  AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+	  Logger::log(Logger::Debug, "AESequenceDC", logMessage);
 	else
 	   // Reactivate the suspended JobDefinition
        generate JobDefinition.reactivate() to theJobDefn;
@@ -535,7 +535,7 @@ begin
   else
     // 
     logMessage := "AESequenceDC::reactivateJobDefinition : The JobDefinition specified for reactivation is unknown - jobName " & jobName;
-	AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+	Logger::log(Logger::Debug, "AESequenceDC", logMessage);
   
   end if;
 end service;
@@ -554,7 +554,7 @@ logMessage : string;
 begin
   // TODO - remove the following log message (added for testing purposes).
   logMessage := "AESequenceDC::extraJobInvariantDefinition : Extra Job Invariant Definition added for "& auditEventDataName;
-  AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+  Logger::log(Logger::Debug, "AESequenceDC", logMessage);
 
   sourceInvariantEventType := (sourceEventType,sourceOccurrenceId,"","");
   ExtraJobInvariantDefn.createSourceExtraJobInvariantDefn(sourceJobDefnName,auditEventDataName, sourceInvariantEventType, @P1D@);
@@ -639,7 +639,7 @@ begin
     else
                       
       logMessage := "AESequenceDC::restoreInvariants : No Extra-Job Invariant Definition of the appropriate name was found so restoring the following Invariant cannot proceed " & restoredInvariant.invariantName;
-      AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+      Logger::log(Logger::Debug, "AESequenceDC", logMessage);
   	                                                                           
     end if;  
                  
@@ -652,7 +652,7 @@ begin
     
     // TODO Remove debug message
     logMessage := "AESequenceDC::restoreInvariants : Additional Source Invariants found so re-evaluate the extra job invariants for Job " & eachJob.jobID;
-    AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+    Logger::log(Logger::Debug, "AESequenceDC", logMessage);
     
     generate Job.StoredInvariantsReceived () to eachJob;
   end loop;
@@ -667,20 +667,20 @@ logMessage : string;
 begin
   theJobDefn := find_one JobDefinition (jobName = jobName);
   logMessage := "AESequenceDC::createJobDefinition : New Job Definition, Job Definition = " & jobName ;
-  AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+  Logger::log(Logger::Debug, "AESequenceDC", logMessage);
   if theJobDefn = null then
     // Event Definition for new Job so create the Job Definition
     theJobDefn := create unique JobDefinition (jobName => jobName, isDeprecated => false, isSuspended => false, Current_State => Active);
     for eventDefinition in eventDefinitions loop
       logMessage := "AESequenceDC::createJobDefinition : New Event Definition, Sequence Name = " & eventDefinition.sequenceName & " event type = " & eventDefinition.eventType & " Start = " & eventDefinition.isSequenceStart'image & " End = " & eventDefinition.isSequenceEnd'image & " Break = " & eventDefinition.isBreak'image & " Happy = " & eventDefinition.isHappy'image & " Critical = " & eventDefinition.isCritical'image ;
-      AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);
+      Logger::log(Logger::Debug, "AESequenceDC", logMessage);
       AESequenceDC::eventDefinition(jobName, eventDefinition.sequenceName, eventDefinition.eventType, eventDefinition.occurrenceId, 
     		                          eventDefinition.previousEventTypes, eventDefinition.isSequenceStart, eventDefinition.isSequenceEnd, 
     		                          eventDefinition.isBreak, eventDefinition.isHappy, eventDefinition.isCritical);
     end loop;
   else
     logMessage := "AESequenceDC::createJobDefinition :  Updates for existing jobs not supported: Job Name = " & jobName;
-    AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);            
+    Logger::log(Logger::Debug, "AESequenceDC", logMessage);            
   end if;
      
 end service;

--- a/models/SequenceVerificationDataCentric/models/SequenceVerificationDataCentric/SVDCdomain/AESequenceDC/scenarios/scenarios.masl
+++ b/models/SequenceVerificationDataCentric/models/SequenceVerificationDataCentric/SVDCdomain/AESequenceDC/scenarios/scenarios.masl
@@ -1994,10 +1994,10 @@ begin
   eventDefinition ("BranchCountJob","BranchCountSequence","BCFF",1,previousEventTypes,false,true,false,true,false);
 
   logMessage := "AESequenceDC::OLD_InitBranchCountDefinition : OLD_InitBranchCountDefinition scenario - Call for Merge Count follows";
-  AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);                       
+  Logger::log(Logger::Debug, "AESequenceDC", logMessage);                       
   createDynamicControlDefinition("BranchCountJob", "Merge_Counter_1", dynamicControlTypeEnum.MERGECOUNT, "BCFA",1,"BCFD",1);
   logMessage := "AESequenceDC::OLD_InitBranchCountDefinition : OLD_InitBranchCountDefinition scenario - Call for Branch Count follows";
-  AsyncLogger::log(Logger::Debug, "AESequenceDC", logMessage);                       
+  Logger::log(Logger::Debug, "AESequenceDC", logMessage);                       
   createDynamicControlDefinition("BranchCountJob", "Branch_Counter_1", dynamicControlTypeEnum.BRANCHCOUNT, "BCFA",1,"BCFB",1);
   
 //

--- a/models/VerificationGateway/models/VerificationGateway/VerificationGatewayDomain/VerificationGateway/GatewayClasses/VerifiableJob/VerifiableJob.masl
+++ b/models/VerificationGateway/models/VerificationGateway/VerificationGatewayDomain/VerificationGateway/GatewayClasses/VerifiableJob/VerifiableJob.masl
@@ -48,7 +48,7 @@ logMessage : string;
 begin
   // Log info: Report that this VerifianleJob is being deleted. 
   logMessage := "Deleting Job " & this.jobKey'image & " and all its InstrumentationEvents";
-  AsyncLogger::log(Logger::Debug, "VerificationGateway", logMessage);
+  Logger::log(Logger::Debug, "VerificationGateway", logMessage);
   
   theLastInstrumentationEvent := this -> R2;
   unlink this R2 theLastInstrumentationEvent;


### PR DESCRIPTION
This change goes back to using Logger instead of AsyncLogger for normal (debug/info) logging.  The use of AsyncLogger was adding too much chatter on the message bus.