### PR TITLE
Update to manage stored job ids

### DIFF
--- a/deploy/config/benchmarking-config.json
+++ b/deploy/config/benchmarking-config.json
@@ -15,7 +15,7 @@
   "DefaultStaleAuditEventDuration": "PT10M",
   "DefaultBlockedAuditEventDuration": "PT55S",
   "JobStoreLocation": "./JobIdStore",
-  "JobStoreAgeLimit": "P7D",
+  "JobStoreAgeLimit": "PT5M",
   "InvariantStoreLoadRate": "PT2M",
   "MaxIntraSequenceEventTimeoutPeriod": "PT5S",
   "WaitPeriodForAllJobsCompletedCheck": "P1D",

--- a/deploy/config/pv-config.json
+++ b/deploy/config/pv-config.json
@@ -15,7 +15,7 @@
   "DefaultStaleAuditEventDuration": "PT10M",
   "DefaultBlockedAuditEventDuration": "PT55S",
   "JobStoreLocation": "./JobIdStore",
-  "JobStoreAgeLimit": "P7D",
+  "JobStoreAgeLimit": "PT1H",
   "InvariantStoreLoadRate": "PT2M",
   "MaxIntraSequenceEventTimeoutPeriod": "PT5S",
   "WaitPeriodForAllJobsCompletedCheck": "P1D",

--- a/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/Job/Job.masl
+++ b/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/Job/Job.masl
@@ -117,8 +117,7 @@ begin
 		end if;
 	end if;
 	// add the job to the job store as there should be no more events
-        // CDS - HACK - re-design to scale
-	//JobStore.addJobToStore(this.jobId);
+	JobStore.addJobToStore(this.jobId);
 	delete this;
 end service;
 //! ACTIVITY END. DO NOT EDIT THIS LINE.

--- a/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/JobStore/InstanceStateMachine/InstanceStateMachine.masl
+++ b/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/JobStore/InstanceStateMachine/InstanceStateMachine.masl
@@ -10,16 +10,33 @@ state AEOrdering::JobStore.JobStoreUpdated () is
 jobStoreArchivedName : string;
 fileStatus : Filesystem::file_status;
 elapsedTime : duration;
+ageOffJobTime : timestamp;
+jobIdsToStore : string;
+jobStoreDevice : Filesystem::file;
 
 begin
 		
-	// move the current job store
-	cancel this.jobStoreTimer;
-	if Filesystem::file_exists(Filesystem::filename(this.jobStoreLocation & "/" & this.jobStoreName)) then
-		jobStoreArchivedName := this.jobStoreName & "-" & Strings::replace_all(timestamp'now'image, ":", "");
-		Filesystem::move_file(Filesystem::filename(this.jobStoreLocation & "/" & this.jobStoreName), Filesystem::filename(this.jobStoreLocation & "/" & jobStoreArchivedName));
+	// write any new StoredJobIdentifiers to file
+    if find_one StoredJobIdentifier(stored = false) /= null then
+	    for storedJobIdentifier in (find StoredJobIdentifier(stored = false)) loop
+			jobIdsToStore := jobIdsToStore & storedJobIdentifier.jobTime'image & " " & storedJobIdentifier.jobId & "\n";
+			storedJobIdentifier.stored := true;
+		end loop;
+	    Filesystem::open_append(Filesystem::filename(this.jobStoreLocation & "/" & this.jobStoreName), jobStoreDevice);
+		jobStoreDevice << jobIdsToStore;
+		Filesystem::close(jobStoreDevice);
 	end if;
 	
+	// if the current job store file creation date is older that the job store age limit then archive it
+	elapsedTime := timestamp'now - this.fileStoreCreationTime;
+	if elapsedTime > this.jobStoreAgeLimit then
+		if Filesystem::file_exists(Filesystem::filename(this.jobStoreLocation & "/" & this.jobStoreName)) then
+			jobStoreArchivedName := this.jobStoreName & "-" & Strings::replace_all(timestamp'now'image, ":", "");
+			Filesystem::move_file(Filesystem::filename(this.jobStoreLocation & "/" & this.jobStoreName), Filesystem::filename(this.jobStoreLocation & "/" & jobStoreArchivedName));
+		end if;
+		this.fileStoreCreationTime := timestamp'now;
+	end if;
+
 	// remove any job stores that are older than the age off limit
 	for file in Filesystem::list_directory(Filesystem::filename(this.jobStoreLocation)) loop
 		fileStatus := Filesystem::get_file_status(Filesystem::filename(this.jobStoreLocation & "/") & file);
@@ -30,13 +47,16 @@ begin
 	end loop;
 	
 	// remove any StoredJobIdentifiers that are older than the age off limit
-	for jobStoreIdentifier in find StoredJobIdentifier() loop
-		elapsedTime := timestamp'now - jobStoreIdentifier.jobTime;
-		if elapsedTime > this.jobStoreAgeLimit then
-			delete jobStoreIdentifier;
-		end if;  
+	ageOffJobTime := timestamp'now - this.jobStoreAgeLimit;
+	for jobStoreIdentifier in find StoredJobIdentifier(jobTime <= ageOffJobTime) loop
+		delete jobStoreIdentifier;
 	end loop;
-	schedule this.jobStoreTimer generate JobStore.purgeJobStore() to this delay @PT24H@;
+//	for jobStoreIdentifier in find StoredJobIdentifier() loop
+//		elapsedTime := timestamp'now - jobStoreIdentifier.jobTime;
+//		if elapsedTime > this.jobStoreAgeLimit then
+//			delete jobStoreIdentifier;
+//		end if;  
+//	end loop;
 	
 end state;
 //! ACTIVITY END. DO NOT EDIT THIS LINE.

--- a/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/JobStore/JobStore.masl
+++ b/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/JobStore/JobStore.masl
@@ -30,20 +30,16 @@ end service;
 
 //! ACTIVITY BEGIN. '47b304fc-89f6-4116-a87e-604aecbf8b4b' DO NOT EDIT THIS LINE.
 public service AEOrdering::JobStore.addJobToStore ( jobId : in string ) is
-jobStore : instance of JobStore;
 storedJobIdentifier : instance of StoredJobIdentifier;
-jobStoreDevice : Filesystem::file;
+eventContent : string;
 
 begin
 	storedJobIdentifier := find_one StoredJobIdentifier(jobId = jobId);
 	if storedJobIdentifier = null then
-		storedJobIdentifier := create StoredJobIdentifier(jobId => jobId, jobTime => timestamp'now);
-		jobStore := find_one JobStore();
-        Filesystem::open_append(Filesystem::filename(jobStore.jobStoreLocation & "/" & jobStore.jobStoreName), jobStoreDevice);
-		jobStoreDevice << storedJobIdentifier.jobTime'image << " " << storedJobIdentifier.jobId << "\n";
-		Filesystem::close(jobStoreDevice);
+		storedJobIdentifier := create StoredJobIdentifier(jobId => jobId, jobTime => timestamp'now, stored => false);
 	else
-	    Logger::log(Logger::Information, "AEOrdering", "Duplicate job id reported to job store JobId = " & jobId);
+	    eventContent := "Duplicate job id reported to job store JobId = " & jobId;
+	    Reporting~>reportEvent(Logger::Error, "aeordering_duplicate_job_id", eventContent);
 	end if;
 end service;
 //! ACTIVITY END. DO NOT EDIT THIS LINE.

--- a/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/JobStore/JobStore.xtuml
+++ b/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/JobStore/JobStore.xtuml
@@ -94,7 +94,7 @@ INSERT INTO O_BATTR
 INSERT INTO O_ATTR
 	VALUES ("9ba96ab7-a390-41b1-b659-d4a5990ffc17",
 	"a470b7ea-0c27-4393-b1bb-05286fda5a75",
-	"d9d90c84-f338-4cee-b9c5-93d02c25ff95",
+	"467483d5-c7f5-4476-b4dd-9de7d37d38d6",
 	'current_state',
 	'',
 	'',
@@ -104,40 +104,15 @@ INSERT INTO O_ATTR
 	'',
 	'');
 INSERT INTO O_NBATTR
-	VALUES ("a81252af-3325-4fa3-9dc3-35f559dae7d6",
+	VALUES ("d9d90c84-f338-4cee-b9c5-93d02c25ff95",
 	"a470b7ea-0c27-4393-b1bb-05286fda5a75");
 INSERT INTO O_BATTR
-	VALUES ("a81252af-3325-4fa3-9dc3-35f559dae7d6",
+	VALUES ("d9d90c84-f338-4cee-b9c5-93d02c25ff95",
 	"a470b7ea-0c27-4393-b1bb-05286fda5a75");
 INSERT INTO O_ATTR
-	VALUES ("a81252af-3325-4fa3-9dc3-35f559dae7d6",
+	VALUES ("d9d90c84-f338-4cee-b9c5-93d02c25ff95",
 	"a470b7ea-0c27-4393-b1bb-05286fda5a75",
 	"86dfada1-3a11-4ff1-890b-6ce33e46265c",
-	'jobStoreTimer',
-	'',
-	'',
-	'jobStoreTimer',
-	0,
-	"f93e8fda-cfc1-49d7-80e2-1a3df8a06efe",
-	'',
-	'');
-INSERT INTO S_DT_PROXY
-	VALUES ("f93e8fda-cfc1-49d7-80e2-1a3df8a06efe",
-	"00000000-0000-0000-0000-000000000000",
-	'timer',
-	'',
-	'',
-	'../../../../types/types.xtuml');
-INSERT INTO O_NBATTR
-	VALUES ("d9d90c84-f338-4cee-b9c5-93d02c25ff95",
-	"a470b7ea-0c27-4393-b1bb-05286fda5a75");
-INSERT INTO O_BATTR
-	VALUES ("d9d90c84-f338-4cee-b9c5-93d02c25ff95",
-	"a470b7ea-0c27-4393-b1bb-05286fda5a75");
-INSERT INTO O_ATTR
-	VALUES ("d9d90c84-f338-4cee-b9c5-93d02c25ff95",
-	"a470b7ea-0c27-4393-b1bb-05286fda5a75",
-	"a81252af-3325-4fa3-9dc3-35f559dae7d6",
 	'jobStoreAgeLimit',
 	'',
 	'',
@@ -150,6 +125,31 @@ INSERT INTO S_DT_PROXY
 	VALUES ("5121b717-dfad-45ae-bb2f-9cb5ed060878",
 	"00000000-0000-0000-0000-000000000000",
 	'duration',
+	'',
+	'',
+	'../../../../types/types.xtuml');
+INSERT INTO O_NBATTR
+	VALUES ("467483d5-c7f5-4476-b4dd-9de7d37d38d6",
+	"a470b7ea-0c27-4393-b1bb-05286fda5a75");
+INSERT INTO O_BATTR
+	VALUES ("467483d5-c7f5-4476-b4dd-9de7d37d38d6",
+	"a470b7ea-0c27-4393-b1bb-05286fda5a75");
+INSERT INTO O_ATTR
+	VALUES ("467483d5-c7f5-4476-b4dd-9de7d37d38d6",
+	"a470b7ea-0c27-4393-b1bb-05286fda5a75",
+	"d9d90c84-f338-4cee-b9c5-93d02c25ff95",
+	'fileStoreCreationTime',
+	'',
+	'',
+	'fileStoreCreationTime',
+	0,
+	"8409038f-e39e-4c48-aa46-57f35c1d3c38",
+	'',
+	'');
+INSERT INTO S_DT_PROXY
+	VALUES ("8409038f-e39e-4c48-aa46-57f35c1d3c38",
+	"00000000-0000-0000-0000-000000000000",
+	'timestamp',
 	'',
 	'',
 	'../../../../types/types.xtuml');

--- a/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/StoredJobIdentifier/StoredJobIdentifier.xtuml
+++ b/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/StoredJobIdentifier/StoredJobIdentifier.xtuml
@@ -108,6 +108,24 @@ INSERT INTO S_DT_PROXY
 	'',
 	'',
 	'../../../../types/types.xtuml');
+INSERT INTO O_NBATTR
+	VALUES ("263e5e3b-b758-4f2a-a990-d72210391adf",
+	"38d82f29-5f56-49f9-8693-f5497858eb44");
+INSERT INTO O_BATTR
+	VALUES ("263e5e3b-b758-4f2a-a990-d72210391adf",
+	"38d82f29-5f56-49f9-8693-f5497858eb44");
+INSERT INTO O_ATTR
+	VALUES ("263e5e3b-b758-4f2a-a990-d72210391adf",
+	"38d82f29-5f56-49f9-8693-f5497858eb44",
+	"7cb2d142-d395-4c89-baad-1d5b393d63be",
+	'stored',
+	'',
+	'',
+	'stored',
+	0,
+	"ba5eda7a-def5-0000-0000-000000000001",
+	'',
+	'');
 INSERT INTO O_ID
 	VALUES (0,
 	"38d82f29-5f56-49f9-8693-f5497858eb44");

--- a/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/SystemSpec/InstanceStateMachine/InstanceStateMachine.masl
+++ b/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/SystemSpec/InstanceStateMachine/InstanceStateMachine.masl
@@ -23,6 +23,8 @@ begin
     	this.loadJobDefinitions(updatedJobDefinitions);
     end if;
     
+    // check the job store and purge if required
+    generate JobStore.purgeJobStore() to (find_one JobStore());
     schedule this.configTimer generate SystemSpec.checkConfigUpdate() to this delay this.specUpdateRate;
 	
 exception

--- a/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/SystemSpec/SystemSpec.masl
+++ b/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/SystemSpec/SystemSpec.masl
@@ -70,8 +70,6 @@ jobStoreLocation : string := "./";
 jobStoreAgeLimit : duration := @P7D@;
 jobStore : instance of JobStore;
 jobStoreName : string := "JobIdStore.log";
-today : sequence of integer;
-midnight : timestamp;
 invariantStoreLoadRate : duration;
 maxIntraSequenceEventTimeoutPeriod : duration := @PT1S@;
 waitPeriodForAllJobsCompletedCheck : duration := @P1D@;
@@ -173,11 +171,8 @@ begin
     	jobStoreName := "JobIdStore" & "-" &  this.startJobGroup'image & "-" & this.endJobGroup'image;
     	jobStoreLocation := jobStoreLocation & "/" & this.startJobGroup'image & "-" & this.endJobGroup'image;
     	Filesystem::create_directory(Filesystem::filename(jobStoreLocation));
-    	jobStore := create JobStore(jobStoreName => jobStoreName, jobStoreLocation => jobStoreLocation, jobStoreAgeLimit => jobStoreAgeLimit, Current_State => Created);
+    	jobStore := create JobStore(jobStoreName => jobStoreName, jobStoreLocation => jobStoreLocation, jobStoreAgeLimit => jobStoreAgeLimit, fileStoreCreationTime => timestamp'now, Current_State => Created);
     	JobStore.loadJobStore();
-    	today := timestamp'now'split_ymd();
-    	midnight := timestamp'combine_ymd(today[1], today[2], today[3] + 1);
-    	schedule jobStore.jobStoreTimer generate JobStore.purgeJobStore() to jobStore at midnight; 
     end if;
 end service;
 //! ACTIVITY END. DO NOT EDIT THIS LINE.

--- a/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/tests/tests.masl
+++ b/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/tests/tests.masl
@@ -656,11 +656,13 @@ begin
 	
 	// check that the job store file exists and contains 
 	jobStore := find_one JobStore();
+	jobStore.jobStoreAgeLimit := @PT1H@;
+	generate JobStore.purgeJobStore() to jobStore;
+	Test::service_event_queue();
 	Assertions::assertTrue((Filesystem::file_exists(Filesystem::filename(jobStore.jobStoreLocation & "/" & jobStore.jobStoreName))), "Test Job Complete: Job store file does not exist");
 	// test purge job store
-	schedule jobStore.jobStoreTimer generate JobStore.purgeJobStore() to jobStore delay @PT1S@;
-	Test::fire_scheduled_timers(timestamp'now + duration'seconds(1));
-	Test::fire_scheduled_timers(timestamp'now + duration'seconds(1));
+	generate JobStore.purgeJobStore() to jobStore;
+	Test::service_event_queue();
 	storedJobIdentifier := find_one StoredJobIdentifier(jobId = jobId1);
     Assertions::assertTrue((storedJobIdentifier /= null), "Test Job Complete: Failed to find StoredJobIdentifier");
 	// check the archived file exists
@@ -668,9 +670,8 @@ begin
 	
 	// check the archived file has been removed
 	jobStore.jobStoreAgeLimit := @PT0S@;
-	schedule jobStore.jobStoreTimer generate JobStore.purgeJobStore() to jobStore delay @PT1S@;
-	Test::fire_scheduled_timers(timestamp'now + duration'seconds(1));
-	Test::fire_scheduled_timers(timestamp'now + duration'seconds(1));
+	generate JobStore.purgeJobStore() to jobStore;
+	Test::service_event_queue();
 	storedJobIdentifier := find_one StoredJobIdentifier(jobId = jobId1);
     Assertions::assertTrue((storedJobIdentifier = null), "Test Job Complete: Failed to find StoredJobIdentifier");
 	Assertions::assertTrue((Filesystem::list_directory(Filesystem::filename(jobStore.jobStoreLocation))'length = 0), "Test Job Complete: Job store file archive not removed");


### PR DESCRIPTION
Stored Job Identifiers were not being purged frequently enough. Updated AEO to improve the mechanism for performing this and set the JobStoreAgeLimit to 1 hour in pc-config and 5 minutes in benchmarking-config.