### PR TITLE
Updates to fix integration issues

### DIFF
--- a/models/JobManagement/models/JobManagement/JMdomain/JobManagement/JMclasses/AuditEvent/AuditEvent.masl
+++ b/models/JobManagement/models/JobManagement/JMdomain/JobManagement/JMclasses/AuditEvent/AuditEvent.masl
@@ -2,7 +2,6 @@
 public instance service JobManagement::AuditEvent.reportAuditEvent ( assignedWorker : in instance of EmployedWorker ) is
 begin
 	
-    //Reporting~>reportEvent(Logger::Error, "jobmanagement_event_written", "");
 	Worker~>reportEvent(assignedWorker.workerId, this.auditEvent);
 	
 end service;

--- a/models/JobManagement/models/JobManagement/JMdomain/JobManagement/JMclasses/EmployedWorker/InstanceStateMachine/InstanceStateMachine.masl
+++ b/models/JobManagement/models/JobManagement/JMdomain/JobManagement/JMclasses/EmployedWorker/InstanceStateMachine/InstanceStateMachine.masl
@@ -7,10 +7,14 @@ end state;
 
 //! ACTIVITY BEGIN. 'fafa08f1-e2d9-4091-aa70-9f3e4eb2da3c' 'ffef72a4-885a-4183-9a8c-8b168eb341de' DO NOT EDIT THIS LINE.
 state JobManagement::EmployedWorker.Registered () is
+eventContent : string;
+
 begin
   
 	// report the worker as registered
 	Worker~>workerRegistered(this.workerId);
+	eventContent := "Worker id = " & string(this.workerId);
+	Reporting~>reportEvent(Logger::Information, "jobmanagement_worker_registered", eventContent);
 	
 end state;
 //! ACTIVITY END. DO NOT EDIT THIS LINE.
@@ -40,7 +44,7 @@ begin
 	if this.failedHeartbeatCount > jmSpec.workerHeartbeatFailureThreshold then
 		generate EmployedWorker.workerDeregistered() to this;
 	    eventContent := "Worker id = " & string(this.workerId);
-	    Reporting~>reportEvent(Logger::Error, "jobmanagement_worker_deregistered_failed_heartbeat", eventContent);
+	    Reporting~>reportEvent(Logger::Information, "jobmanagement_worker_deregistered_failed_heartbeat", eventContent);
 	else
 		// schedule the absence timer
 		schedule this.absenceTimer generate EmployedWorker.workerPresenceUnknown() to this delay jmSpec.workerHeartbeatRate;

--- a/models/JobManagement/models/JobManagement/JMdomain/JobManagement/JMclasses/JobManager/JobManager.masl
+++ b/models/JobManagement/models/JobManagement/JMdomain/JobManagement/JMclasses/JobManager/JobManager.masl
@@ -32,7 +32,7 @@ begin
 			end loop;
 			
 		    eventContent := "Job assigned. Worker id = " & string(employedWorker.workerId) & " Jobs assigned = " & ((employedWorker -> R6.AssignedJob)'length)'image;
-		    Reporting~>reportEvent(Logger::Error, "jobmanagement_worker_assigned_job_count", eventContent);
+		    Reporting~>reportEvent(Logger::Information, "jobmanagement_worker_assigned_job_count", eventContent);
 		else
 			// log an error as there is an unassigned job held by job manager but there is no instance of unassigned job
 			logMessage := "Found unassigned job id without an unassigned job, jobId = " & unassignedJobIds[unassignedJobIds'first];
@@ -107,10 +107,10 @@ eventContent : string;
 begin
 
 	eventContent := "Assigned jobs. Job Count = " & ((this -> R1.JobWorker -> R2.EmployedWorker -> R6.AssignedJob)'length)'image;
-	Reporting~>reportEvent(Logger::Error, "jobmanagement_total_assigned_jobs", eventContent);
+	Reporting~>reportEvent(Logger::Information, "jobmanagement_total_assigned_jobs", eventContent);
 
 	eventContent := "Unassigned jobs. Job Count = " & ((find UnassignedJob())'length)'image;
-	Reporting~>reportEvent(Logger::Error, "jobmanagement_total_unassigned_jobs", eventContent);
+	Reporting~>reportEvent(Logger::Information, "jobmanagement_total_unassigned_jobs", eventContent);
 
 end service;
 //! ACTIVITY END. DO NOT EDIT THIS LINE.

--- a/models/JobManagement/models/JobManagement/JMdomain/JobManagement/JMclasses/JobStore/InstanceStateMachine/InstanceStateMachine.masl
+++ b/models/JobManagement/models/JobManagement/JMdomain/JobManagement/JMclasses/JobStore/InstanceStateMachine/InstanceStateMachine.masl
@@ -15,10 +15,8 @@ begin
 	// remove any StoredJobIdentifiers that are older than the age off limit and add the to the archive
 	ageOffJobTime := timestamp'now - this.jobStoreAgeLimit;
 	for jobStoreIdentifier in find StoredJobIdentifier(jobTime <= ageOffJobTime) loop
-		jobIdsToStore := jobIdsToStore & jobStoreIdentifier.jobTime'image & " " & jobStoreIdentifier.jobId & "\n";
 		delete jobStoreIdentifier;
 	end loop;
-	Logger::log(Logger::Information, "JobIdStore", jobIdsToStore);
 	
 	
 end state;

--- a/models/JobManagement/models/JobManagement/JMdomain/JobManagement/JMclasses/JobWorker/JobWorker.masl
+++ b/models/JobManagement/models/JobManagement/JMdomain/JobManagement/JMclasses/JobWorker/JobWorker.masl
@@ -73,17 +73,17 @@ begin
 			delete assignedJob;
 			unassignedJob := create UnassignedJob(jobId => job.jobId);
 			link unassignedJob R5.Job job;
-			unassignedJobIds := jobManager.unassignedJobIds;
 			unassignedJobIds := unassignedJobIds & job.jobId;
-        	jobManager.unassignedJobIds := unassignedJobIds;        	
 		end loop;
+		unassignedJobIds := unassignedJobIds & jobManager.unassignedJobIds;
+		jobManager.unassignedJobIds := unassignedJobIds;
 		// report the worker as unregistered
 		Worker~>workerUnregistered(workerId);
 		unlink employedWorker R2.JobWorker this;
 		delete employedWorker;
 	end if;
 	// create the employed worker
-	retiredWorker := create RetiredWorker(workerId => this.workerId);
+	retiredWorker := create RetiredWorker(workerId => this.workerId, retirementDate => timestamp'now);
 	link retiredWorker R2 this;
     
     // if we have unassigned jobs attempt to assign

--- a/models/JobManagement/models/JobManagement/JMdomain/JobManagement/functions/functions.masl
+++ b/models/JobManagement/models/JobManagement/JMdomain/JobManagement/functions/functions.masl
@@ -24,7 +24,7 @@ begin
 			if employedWorker.working = true then
 				generate EmployedWorker.workerDeregistered() to employedWorker;
 			    eventContent := "Worker id = " & string(employedWorker.workerId);
-			    Reporting~>reportEvent(Logger::Error, "jobmanagement_worker_deregistered_register_request", eventContent);
+			    Reporting~>reportEvent(Logger::Information, "jobmanagement_worker_deregistered_register_request", eventContent);
 			end if;
 		end if;
 	end if;
@@ -67,7 +67,6 @@ begin
         jsonObject := JSON::get_object(jsonElement);
         if jsonObject'contains("jobId") then
 	        jobId := JSON::get_string(jsonObject["jobId"]);
-//	        Reporting~>reportEvent(Logger::Error, "jobmanagement_event_received", "");
 	        jobManager := find_one JobManager();
 	        job := find_one Job(jobId = jobId);
 	        if job = null then
@@ -102,7 +101,7 @@ begin
 	        jmSpec := find_one JobManagementSpec();
 	        if unassignedJobIds'length > jmSpec.maxUnassignedJobs and jmSpec.maxUnaasignedJobsExceeded = false then
 		        eventContent := "Maximum number of of unassigned jobs exceeded. Job Count = " & (unassignedJobIds'length)'image;
-		        Reporting~>reportEvent(Logger::Error, "jobmanagement_exceeded_max_jobs", eventContent);
+		        Reporting~>reportEvent(Logger::Information, "jobmanagement_exceeded_max_jobs", eventContent);
 		        jmSpec.maxUnaasignedJobsExceeded := true;
 		    else
 		        jmSpec.maxUnaasignedJobsExceeded := false;
@@ -151,8 +150,11 @@ begin
 			// report completed job
 			jobManager := find_one JobManager();
 		    eventContent := "Job completed. Worker id = " & string(employedWorker.workerId) & " Jobs assigned = " & ((employedWorker -> R6.AssignedJob)'length)'image;
-		    Reporting~>reportEvent(Logger::Error, "jobmanagement_worker_assigned_job_count", eventContent);
+		    Reporting~>reportEvent(Logger::Information, "jobmanagement_worker_assigned_job_count", eventContent);
         	jobManager.reportJobAssignments();	        	
+			
+			// we have had comms from the worker so reset the heartbeat failure count
+			employedWorker.failedHeartbeatCount := 0;;
 			
 			// check if there are not unassigned jobs and if there are and this employed worker has capacity then assign the job
 			unassignedJobIds := jobManager.unassignedJobIds;
@@ -177,7 +179,7 @@ begin
 	if employedWorker /= null then
 		generate EmployedWorker.workerDeregistered() to employedWorker;
 	    eventContent := "Worker id = " & string(employedWorker.workerId);
-	    Reporting~>reportEvent(Logger::Error, "jobmanagement_worker_deregistered_deregister_request", eventContent);
+	    Reporting~>reportEvent(Logger::Information, "jobmanagement_worker_deregistered_deregister_request", eventContent);
 	end if;
 end service;
 //! ACTIVITY END. DO NOT EDIT THIS LINE.

--- a/models/JobManagement/schedule/test.sch
+++ b/models/JobManagement/schedule/test.sch
@@ -2,6 +2,7 @@
 RUN SCENARIO JobManagement 1 "init"
 
 # run tests
+PAUSE
 RUN SCENARIO Test 1 "run_test" [JobManagement testConfigData 101]
 RUN SCENARIO Test 1 "run_test" [JobManagement testRegisterWorker 102]
 RUN SCENARIO Test 1 "run_test" [JobManagement testWorkerHeartbeat 103]


### PR DESCRIPTION
Fixed issue with retirement data for worker not being ste.

Removed the periodic writing of completed Job Ids to a file. Job Ids are now stored for a configurable time and then deleted.

Put jobs being processed by a worker that becomes retired to front of queue.

Reset the heartbeat counter when the jobComplete has been received.

Added logging fro when a worker becomes registered.