### PR TITLE
job:  #188  clean up build

### DIFF
--- a/models/AEReception/conanfile.py
+++ b/models/AEReception/conanfile.py
@@ -16,7 +16,6 @@ class ConanFile(conan.ConanFile):
     def requirements(self):
         self.requires(f'masl_core/{os.environ["MASL_VERSION"]}@xtuml/stable')
         self.requires(f'masl_utils/{os.environ["MASL_VERSION"]}@xtuml/stable')
-        self.requires(f'asynclogger/{self.version}@xtuml/stable')
 
     def build_requirements(self):
         self.tool_requires(f'masl_codegen/{os.environ["MASL_VERSION"]}@xtuml/stable')

--- a/models/PV_PROC/conanfile.py
+++ b/models/PV_PROC/conanfile.py
@@ -13,7 +13,6 @@ class ConanFile(conan.ConanFile):
     def requirements(self):
         self.requires(f'masl_core/{os.environ["MASL_VERSION"]}@xtuml/stable')
         self.requires(f'masl_utils/{os.environ["MASL_VERSION"]}@xtuml/stable')
-        self.requires(f'benchmarkingprobe/{self.version}@xtuml/stable')
         self.requires(f'aeordering/{self.version}@xtuml/stable')
         self.requires(f'freception/{self.version}@xtuml/stable')
         self.requires(f'istore/{self.version}@xtuml/stable')

--- a/models/PV_PROC/masl/PV_PROC/LOGGER_PROC.prj
+++ b/models/PV_PROC/masl/PV_PROC/LOGGER_PROC.prj
@@ -1,4 +1,0 @@
-project LOGGER_PROC is
-  domain AsyncLogger is
-  end domain;
-end project;

--- a/models/PV_PROC/masl/PV_PROC/PV_PROC.prj
+++ b/models/PV_PROC/masl/PV_PROC/PV_PROC.prj
@@ -135,11 +135,4 @@ project PV_PROC is
   domain VerificationGateway is
   end domain;
 
-  // This domain is included so the empty implementation is used
-  domain BenchmarkingProbe is
-  end domain;
-
-  domain AsyncLogger is
-  end domain;
-  
 end project;

--- a/models/VerificationGateway/conanfile.py
+++ b/models/VerificationGateway/conanfile.py
@@ -14,7 +14,6 @@ class ConanFile(conan.ConanFile):
     def requirements(self):
         self.requires(f'masl_core/{os.environ["MASL_VERSION"]}@xtuml/stable')
         self.requires(f'masl_utils/{os.environ["MASL_VERSION"]}@xtuml/stable')
-        self.requires(f'asynclogger/{self.version}@xtuml/stable')
 
     def build_requirements(self):
         self.tool_requires(f'masl_codegen/{os.environ["MASL_VERSION"]}@xtuml/stable')


### PR DESCRIPTION
I had left some references to aysnclogger and benchmarking probe in the build artefacts.  I have removed them but have kept AsyncLogger and BenchmarkingProbe (and AEReception) in place. These will be deleted after a bit more mileage on the Logger based versions of them.