### PR TITLE
job:  #224  fix bug in JM/AEO bring-up

### DIFF
--- a/metrics/run_benchmark.sh
+++ b/metrics/run_benchmark.sh
@@ -94,11 +94,13 @@ echo "0 of " $TOTAL_EVENTS
 LOOP_COUNT=0
 for ((i = 0; i < $ITERATIONS; i++)); do
   echo ${puml_files} | xargs $P2J --play --msgbroker localhost:9092 --topic $RECEPTION_TOPIC --shuffle --rate $EVENTS_PER_SECOND --num-events $BATCH_OF_EVENTS
-  # Inject an error to fail one job.
-  echo "Inject error to fail a job."
-  $P2J ${puml_file_for_injection} --play --msgbroker localhost:9092 --topic $RECEPTION_TOPIC --omit C
-  echo "Inject error to alarm a job."
-  $P2J ${puml_file_for_alarm} --play --msgbroker localhost:9092 --topic $RECEPTION_TOPIC --sibling CSJC
+  if [[ $# -lt 3 ]] ; then
+    # Inject an error to fail one job.
+    echo "Inject error to fail a job."
+    $P2J ${puml_file_for_injection} --play --msgbroker localhost:9092 --topic $RECEPTION_TOPIC --omit C
+    echo "Inject error to alarm a job."
+    $P2J ${puml_file_for_alarm} --play --msgbroker localhost:9092 --topic $RECEPTION_TOPIC --sibling CSJC
+  fi
   LOOP_COUNT=$(($LOOP_COUNT + 1))
   echo $(($LOOP_COUNT * $BATCH_OF_EVENTS)) " of " $TOTAL_EVENTS
 done
@@ -109,6 +111,10 @@ events_per_second=$(($TOTAL_EVENTS / $runtime))
 echo $runtime "seconds at rate:" $events_per_second >> runtime.txt
 sleep 20
 echo "Done."
+if [[ $# -ge 3 ]] ; then
+  echo "Press ENTER to continue..."
+  read a
+fi
 
 # run the benchmark script
 echo "Running benchmark calculations..."

--- a/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/Worker/InstanceStateMachine/InstanceStateMachine.masl
+++ b/models/AEOrdering/models/AEOrdering/AEOdomain/AEOrdering/AEOclasses/Worker/InstanceStateMachine/InstanceStateMachine.masl
@@ -21,7 +21,7 @@ state AEOrdering::Worker.Registered () is
 begin
 	cancel this.workerTimer;
 	this.registered := true;
-	schedule this.workerTimer generate Worker.reportHeartbeat() to this delay this.heartbeatRate;
+	schedule this.workerTimer generate Worker.reportHeartbeat() to this delay @PT0S@;
 end state;
 //! ACTIVITY END. DO NOT EDIT THIS LINE.
 

--- a/models/JobManagement/models/JobManagement/JMdomain/JobManagement/JMclasses/JobManager/JobManager.masl
+++ b/models/JobManagement/models/JobManagement/JMdomain/JobManagement/JMclasses/JobManager/JobManager.masl
@@ -67,7 +67,7 @@ begin
 	while noWorkersAvailable = false loop
 		// check worker capacity
 		employedWorker := nextWorker -> R2.EmployedWorker;
-		if employedWorker /= null and (employedWorker -> R6.AssignedJob)'length < jmSpec.maxJobsPerWorker then
+		if employedWorker /= null and employedWorker.working and (employedWorker -> R6.AssignedJob)'length < jmSpec.maxJobsPerWorker then
 				
 			// set up the next worker to be assigned
 			unlink this R4;


### PR DESCRIPTION
In a conversation, I learned that JM is expecting to begin assigning work to an EmployedWorker only after receiving the first heartbeat. This was not happening.  A small change to JM to include 'working' in the selection of a worker for an assignment together with a small change in AEO to provide a first heartbeat upon successful registration. We seem to be synchronised now.